### PR TITLE
Potential fix for code scanning alert no. 37: Incomplete string escaping or encoding

### DIFF
--- a/core-api/src/modules/tools/tools-privider/built-in-tools.ts
+++ b/core-api/src/modules/tools/tools-privider/built-in-tools.ts
@@ -65,7 +65,7 @@ export const builtInTools: Tool[] = [
         .trim()
         .split('\n')
         .filter((i) => i.includes(':'))
-        .map((i) => Number(i.split(':')[1].replace('\r', '')))
+        .map((i) => Number(i.split(':')[1].replace(/\r/g, '')))
         .sort();
       return parsed;
     },


### PR DESCRIPTION
Potential fix for [https://github.com/oasm-platform/open-asm/security/code-scanning/37](https://github.com/oasm-platform/open-asm/security/code-scanning/37)

In general, when sanitizing or normalizing strings, use a global regular expression or a dedicated utility so that *all* occurrences of a character are handled, not just the first. For removing all carriage returns, this means using `.replace(/\r/g, '')` (or a more general whitespace/line-ending normalization) instead of `.replace('\r', '')`.

For this specific case in `core-api/src/modules/tools/tools-privider/built-in-tools.ts`, the best minimally invasive fix is to change the `.replace('\r', '')` call on line 68 to `.replace(/\r/g, '')`. This preserves existing behavior for typical inputs (a single trailing `\r`) while correctly handling any line that might contain multiple `\r` characters. No other logic needs to change: we still split the line on `:`, take the second part as the port string, strip `\r` characters, convert it to `Number`, and sort the resulting array. No additional imports or helper methods are required.

Concretely:
- Edit the `parser` function in the `naabu` tool definition.
- On the line:
  ```ts
  .map((i) => Number(i.split(':')[1].replace('\r', '')))
  ```
  replace `.replace('\r', '')` with `.replace(/\r/g, '')`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
