### PR TITLE
feat(core-api): show asset in vulnerability detail and list

### DIFF
--- a/console/src/pages/vulnerabilities/detail-vulnerability.tsx
+++ b/console/src/pages/vulnerabilities/detail-vulnerability.tsx
@@ -34,7 +34,7 @@ import {
   XCircle,
 } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'sonner';
 import { DismissAlertDialog } from './components/dismiss-dialog';
 
@@ -397,7 +397,17 @@ export default function DetailVulnerability() {
                           </div>
                         </div>
                       )}
-                      {data.host && (
+                      {data.asset && (
+                        <div className="md:col-span-2">
+                          <span className="block mb-1">Asset</span>
+                          <Link
+                            to={`/assets?tab=service&filter=${data.asset.value}`}
+                          >
+                            {data.asset.value}
+                          </Link>
+                        </div>
+                      )}
+                      {/* {data.host && (
                         <div className="md:col-span-2">
                           <span className="block mb-1">Host</span>
                           <div className="flex items-start gap-2">
@@ -407,7 +417,7 @@ export default function DetailVulnerability() {
                             <CopyButton text={data.host} />
                           </div>
                         </div>
-                      )}
+                      )} */}
                       {data.ipAddress && (
                         <div>
                           <span className="block mb-1">IP Address</span>
@@ -564,7 +574,9 @@ export default function DetailVulnerability() {
                         variant="outline"
                         className="flex items-center gap-1 h-8 rounded-md cursor-pointer hover:bg-accent transition-colors"
                         onClick={() =>
-                          navigate(`/vulnerabilities?tags=${encodeURIComponent(tag)}`)
+                          navigate(
+                            `/vulnerabilities?tags=${encodeURIComponent(tag)}`,
+                          )
                         }
                       >
                         <Tag size={16} /> {tag}

--- a/console/src/pages/vulnerabilities/vulnerablity-columns.tsx
+++ b/console/src/pages/vulnerabilities/vulnerablity-columns.tsx
@@ -11,7 +11,7 @@ import {
 import { AnalyzeStatusButton } from '@/components/vulnerabilities/analyze-status-button';
 import type { Vulnerability } from '@/services/apis/gen/queries';
 import type { ColumnDef } from '@tanstack/react-table';
-import { BellOff, CircleCheck, ExternalLink, Info } from 'lucide-react';
+import { BellOff, CircleCheck, Info } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import BadgeList from '../assets/components/badge-list';
 
@@ -98,35 +98,15 @@ export const vulnerabilityColumns: ColumnDef<Vulnerability, unknown>[] = [
     },
   },
   {
-    accessorKey: 'affectedUrl',
-    header: 'Affected URL',
+    accessorKey: 'asset',
+    header: 'Asset',
     size: 200,
     cell: ({ row }) => {
-      const value: string = row.getValue('affectedUrl');
+      const data = row.original;
+      const value: string = data.asset?.value || data.affectedUrl;
       return (
         <div className="flex items-center min-h-[60px]">
-          {value ? (
-            <div className="flex items-center gap-1">
-              <a
-                href={value}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-500 shrink-0 flex items-center gap-1"
-              >
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="truncate max-w-[200px]">{value}</span>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <p>{value}</p>
-                  </TooltipContent>
-                </Tooltip>
-                <ExternalLink size={14} />
-              </a>
-            </div>
-          ) : (
-            <div className="text-muted-foreground">Not matched</div>
-          )}
+          <b>{value}</b>
         </div>
       );
     },

--- a/console/src/services/apis/gen/queries.ts
+++ b/console/src/services/apis/gen/queries.ts
@@ -1259,6 +1259,7 @@ export type Vulnerability = {
   publicationDate: string;
   modificationDate: string;
   tool: Tool;
+  asset: Asset;
   vulnerabilityDismissal: VulnerabilityDismissal;
   analyzeStatus: VulnerabilityAnalyzeStatus;
   analyzeResult: string;

--- a/core-api/src/modules/vulnerabilities/entities/vulnerability.entity.ts
+++ b/core-api/src/modules/vulnerabilities/entities/vulnerability.entity.ts
@@ -133,6 +133,7 @@ export class Vulnerability extends BaseEntity {
   @ManyToOne(() => Tool, (tool) => tool.vulnerabilities)
   tool: Tool;
 
+  @ApiProperty({ type: () => Asset })
   @ManyToOne(() => Asset, (asset) => asset.vulnerabilities, {
     onDelete: 'CASCADE',
   })

--- a/core-api/src/modules/vulnerabilities/vulnerabilities.service.ts
+++ b/core-api/src/modules/vulnerabilities/vulnerabilities.service.ts
@@ -114,6 +114,7 @@ export class VulnerabilitiesService {
     const queryBuilder = this.vulnerabilitiesRepository
       .createQueryBuilder('vulnerabilities')
       .leftJoin('vulnerabilities.asset', 'assets')
+      .addSelect(['assets.id', 'assets.value'])
       .leftJoin('assets.target', 'targets')
       .leftJoin('targets.workspaceTargets', 'workspace_targets')
       .leftJoin('workspace_targets.workspace', 'workspaces')
@@ -199,6 +200,7 @@ export class VulnerabilitiesService {
     const queryBuilder = this.vulnerabilitiesRepository
       .createQueryBuilder('vulnerabilities')
       .leftJoin('vulnerabilities.asset', 'assets')
+      .addSelect(['assets.id', 'assets.value'])
       .leftJoin('assets.target', 'targets')
       .leftJoin('targets.workspaceTargets', 'workspace_targets')
       .leftJoin('workspace_targets.workspace', 'workspaces')


### PR DESCRIPTION
- Add asset field to vulnerability entity and API response
- Select asset value in vulnerability queries
- Replace affectedUrl column with asset in vulnerability table
- Display asset link in vulnerability detail page