### PR TITLE
feat(core-api): add sticky worker session for conversation remote execution

### DIFF
--- a/core-api/src/database/migrations/1780414902505-AddConversationWorkerId.ts
+++ b/core-api/src/database/migrations/1780414902505-AddConversationWorkerId.ts
@@ -1,0 +1,16 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddConversationWorkerId1780414902505 implements MigrationInterface {
+    name = 'AddConversationWorkerId1780414902505'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "agent_conversations" ADD "workerId" uuid`);
+        await queryRunner.query(`ALTER TABLE "agent_mcp_configs" ALTER COLUMN "configJson" SET DEFAULT '{"mcpServers":{}}'`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "agent_mcp_configs" ALTER COLUMN "configJson" SET DEFAULT '{"mcpServers": {}}'`);
+        await queryRunner.query(`ALTER TABLE "agent_conversations" DROP COLUMN "workerId"`);
+    }
+
+}

--- a/core-api/src/modules/agents/agents.completions.ts
+++ b/core-api/src/modules/agents/agents.completions.ts
@@ -1509,6 +1509,7 @@ export class AgentsCompletionsService {
         workspaceId,
         agentMode,
         todosEmitter,
+        conversation.id,
       ) as ToolSet),
       ...(this.agentTool.getTodoTools(
         conversation.id,

--- a/core-api/src/modules/agents/agents.tools.ts
+++ b/core-api/src/modules/agents/agents.tools.ts
@@ -348,7 +348,7 @@ export class AgentTool {
     };
   }
 
-  remoteExecuteTool(workspaceId: string, emitter?: EventEmitter): ToolType {
+  remoteExecuteTool(workspaceId: string, conversationId: string, emitter?: EventEmitter): ToolType {
     const toolConfig: any = {
       description: [
         'Execute arbitrary shell commands on remote worker nodes (nmap, curl, dig, etc.).',
@@ -370,6 +370,7 @@ export class AgentTool {
         return this.remoteExecuteService.waitForResult(
           command,
           sessionId,
+          conversationId,
           60_000,
           (event) => {
             if (emitter) {
@@ -467,6 +468,7 @@ export class AgentTool {
     workspaceId: string,
     agentMode: AgentMode,
     emitter?: EventEmitter,
+    conversationId?: string,
   ): Record<string, ToolType> {
     const { AGENT, ASK } = AgentMode;
     const tools: Record<string, { method: ToolType; permissions: AgentMode[] }> = {
@@ -486,7 +488,7 @@ export class AgentTool {
       display_available_tools: { method: this.listToolsTool(workspaceId), permissions: [AGENT, ASK] },
       list_active_workers: { method: this.listWorkersTool(workspaceId), permissions: [AGENT, ASK] },
       review_jobs: { method: this.listJobsTool(workspaceId), permissions: [AGENT, ASK] },
-      execute_remote_command: { method: this.remoteExecuteTool(workspaceId, emitter), permissions: [AGENT] },
+      execute_remote_command: { method: this.remoteExecuteTool(workspaceId, conversationId ?? '', emitter), permissions: [AGENT] },
     };
 
     return Object.fromEntries(

--- a/core-api/src/modules/agents/entities/agent-conversation.entity.ts
+++ b/core-api/src/modules/agents/entities/agent-conversation.entity.ts
@@ -77,4 +77,10 @@ export class AgentConversation {
   @IsString()
   @Column({ type: 'text', nullable: true })
   summary?: string;
+
+  @ApiProperty({ description: 'Pinned worker for remote execution', required: false })
+  @IsOptional()
+  @IsUUID()
+  @Column({ type: 'uuid', nullable: true })
+  workerId?: string;
 }

--- a/core-api/src/modules/remote-execute/remote-execute.service.ts
+++ b/core-api/src/modules/remote-execute/remote-execute.service.ts
@@ -121,6 +121,7 @@ export class RemoteExecuteService {
   async waitForResult(
     command: string,
     sessionId: string,
+    conversationId: string,
     timeoutMs = 60_000,
     onEvent?: (event: { type: ResultEventType; data: string; exitCode: number }) => void,
   ): Promise<RemoteCommandResult> {
@@ -176,8 +177,6 @@ export class RemoteExecuteService {
             `[waitForResult] Command finished, type=${event.type}`,
           );
 
-          this.remoteExecuteSubscribeService.removeSession(sessionId);
-
           this.redisService
             .unsubscribe(channel)
             .catch((err) => {
@@ -198,8 +197,8 @@ export class RemoteExecuteService {
     this.logger.log(`[waitForResult] Subscription confirmed, pushing command`);
 
     const pushResult =
-      this.remoteExecuteSubscribeService.pushCommandWithSession(
-        sessionId,
+      await this.remoteExecuteSubscribeService.pushCommandWithConversation(
+        conversationId,
         command,
       );
 

--- a/core-api/src/modules/remote-execute/remote-execute.service.ts
+++ b/core-api/src/modules/remote-execute/remote-execute.service.ts
@@ -177,6 +177,8 @@ export class RemoteExecuteService {
             `[waitForResult] Command finished, type=${event.type}`,
           );
 
+          this.remoteExecuteSubscribeService.removeSession(sessionId);
+
           this.redisService
             .unsubscribe(channel)
             .catch((err) => {
@@ -199,6 +201,7 @@ export class RemoteExecuteService {
     const pushResult =
       await this.remoteExecuteSubscribeService.pushCommandWithConversation(
         conversationId,
+        sessionId,
         command,
       );
 

--- a/core-api/src/modules/workers/remote-execute-subscribe.service.ts
+++ b/core-api/src/modules/workers/remote-execute-subscribe.service.ts
@@ -149,10 +149,11 @@ export class RemoteExecuteSubscribeService implements OnModuleDestroy {
 
   async pushCommandWithConversation(
     conversationId: string,
+    sessionId: string,
     command: string,
   ): Promise<RemoteExecuteCommand | null> {
     if (!conversationId) {
-      return this.pushCommandWithSession(nanoid(), command);
+      return this.pushCommandWithSession(sessionId, command);
     }
 
     const conversation = await this.conversationRepo.findOne({
@@ -166,7 +167,7 @@ export class RemoteExecuteSubscribeService implements OnModuleDestroy {
       );
       return this.pushCommand(
         conversation.workerId,
-        `conv:${conversationId}`,
+        sessionId,
         command,
       );
     }
@@ -191,7 +192,7 @@ export class RemoteExecuteSubscribeService implements OnModuleDestroy {
     this.logger.log(
       `[StickyWorker] Assigned worker ${workerId} to conversation ${conversationId}`,
     );
-    return this.pushCommand(workerId, conversationId, command);
+    return this.pushCommand(workerId, sessionId, command);
   }
 
   removeSession(sessionId: string): void {

--- a/core-api/src/modules/workers/remote-execute-subscribe.service.ts
+++ b/core-api/src/modules/workers/remote-execute-subscribe.service.ts
@@ -1,6 +1,15 @@
-import { forwardRef, Inject, Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import { AgentConversation } from '@/modules/agents/entities/agent-conversation.entity';
+import {
+  forwardRef,
+  Inject,
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
 import { nanoid } from 'nanoid';
 import { finalize, ReplaySubject } from 'rxjs';
+import { Repository } from 'typeorm';
 import { WorkerInstance } from './entities/worker.entity';
 import { WorkersService } from './workers.service';
 
@@ -31,6 +40,8 @@ export class RemoteExecuteSubscribeService implements OnModuleDestroy {
   constructor(
     @Inject(forwardRef(() => WorkersService))
     private readonly workersService: WorkersService,
+    @InjectRepository(AgentConversation)
+    private readonly conversationRepo: Repository<AgentConversation>,
   ) {}
 
   registerWorker(worker: WorkerInstance): WorkerRegistration {
@@ -134,6 +145,53 @@ export class RemoteExecuteSubscribeService implements OnModuleDestroy {
     }
 
     return this.pushCommand(workerId, sessionId, command);
+  }
+
+  async pushCommandWithConversation(
+    conversationId: string,
+    command: string,
+  ): Promise<RemoteExecuteCommand | null> {
+    if (!conversationId) {
+      return this.pushCommandWithSession(nanoid(), command);
+    }
+
+    const conversation = await this.conversationRepo.findOne({
+      where: { id: conversationId },
+      select: ['id', 'workerId'],
+    });
+
+    if (conversation?.workerId && this.isWorkerAlive(conversation.workerId)) {
+      this.logger.verbose(
+        `[StickyWorker] Using pinned worker ${conversation.workerId} for conversation ${conversationId}`,
+      );
+      return this.pushCommand(
+        conversation.workerId,
+        `conv:${conversationId}`,
+        command,
+      );
+    }
+
+    const workerId = this.getNextAvailableWorker();
+    if (!workerId) {
+      return null;
+    }
+
+    if (conversation) {
+      await this.conversationRepo
+        .createQueryBuilder()
+        .update(AgentConversation)
+        .set({ workerId })
+        .where('id = :id AND ("workerId" IS NULL OR "workerId" != :workerId)', {
+          id: conversationId,
+          workerId,
+        })
+        .execute();
+    }
+
+    this.logger.log(
+      `[StickyWorker] Assigned worker ${workerId} to conversation ${conversationId}`,
+    );
+    return this.pushCommand(workerId, conversationId, command);
   }
 
   removeSession(sessionId: string): void {

--- a/core-api/src/modules/workers/workers.module.ts
+++ b/core-api/src/modules/workers/workers.module.ts
@@ -7,6 +7,7 @@ import { NetworkInterface } from '../internal-networks/entities/network-interfac
 import { Job } from '../jobs-registry/entities/job.entity';
 import { WorkspaceTool } from '../tools/entities/workspace_tools.entity';
 import { ToolsModule } from '../tools/tools.module';
+import { AgentConversation } from '@/modules/agents/entities/agent-conversation.entity';
 import { AliveStreamManager } from './alive-stream-manager.service';
 import { WorkerInstance } from './entities/worker.entity';
 import { WorkersController } from './workers.controller';
@@ -24,6 +25,7 @@ import { GrpcWorkerContext } from '@/common/guards/grpc-worker-context.service';
       WorkspaceTool,
       NetworkInterface,
       InternalNetwork,
+      AgentConversation,
     ]),
     ApiKeysModule,
     forwardRef(() => ToolsModule),


### PR DESCRIPTION
Pin conversations to specific workers so subsequent commands in the same conversation reuse the same worker. Adds workerId column to AgentConversation entity and pushCommandWithConversation method in RemoteExecuteSubscribeService that checks for a pinned worker before falling back to round-robin assignment.