### PR TITLE
refactor(core-api): fix agent completions and add memory tools

### DIFF
--- a/console/src/hooks/use-agent-chat.ts
+++ b/console/src/hooks/use-agent-chat.ts
@@ -262,7 +262,14 @@ export function useAgentChat({
       if (data.type === 'data-todos-updated') {
         const payload = data.data as { todos: AgentTodoItem[] } | undefined;
         if (payload?.todos) {
-          setTodos(payload.todos);
+          // Use functional update to avoid stale closure issues
+          setTodos((prevTodos) => {
+            // Skip update if todos are the same (avoid infinite re-renders)
+            if (JSON.stringify(prevTodos) === JSON.stringify(payload.todos)) {
+              return prevTodos;
+            }
+            return payload.todos;
+          });
         }
       }
       if (data.type === 'data-remote-execute-output') {
@@ -284,7 +291,15 @@ export function useAgentChat({
   useEffect(() => {
     if (!conversationId || isLoadingHistory || isStreamingRef.current) return;
     if (savedMessages.length > 0) {
-      setMessages(savedMessages);
+      // Use functional update to compare and avoid unnecessary re-renders
+      setMessages((prev) => {
+        // Skip if messages are the same length and have same IDs
+        if (prev.length === savedMessages.length) {
+          const sameIds = prev.every((m, i) => m.id === savedMessages[i]?.id);
+          if (sameIds) return prev;
+        }
+        return savedMessages;
+      });
     }
   }, [conversationId, isLoadingHistory, savedMessages, setMessages]);
 
@@ -352,18 +367,31 @@ export function useAgentChat({
       return;
     }
 
+    // Use a flag to prevent setting state after unmount
+    let cancelled = false;
+
     orvalClient<ConversationResponseDto>({
       url: `/api/agents/conversations/${conversationId}`,
       method: 'GET',
     })
       .then((data) => {
-        if (data.todos) {
-          setTodos(data.todos as unknown as AgentTodoItem[]);
+        if (!cancelled && data.todos) {
+          setTodos((prev) => {
+            // Only update if different
+            if (JSON.stringify(prev) === JSON.stringify(data.todos)) {
+              return prev;
+            }
+            return data.todos as unknown as AgentTodoItem[];
+          });
         }
       })
       .catch(() => {
         // Silently fail - todos will be empty
       });
+
+    return () => {
+      cancelled = true;
+    };
   }, [conversationId]);
 
   // Auto-send pending message from landing page

--- a/core-api/src/database/migrations/1780700000000-AddAgentLLMConfigLimits.ts
+++ b/core-api/src/database/migrations/1780700000000-AddAgentLLMConfigLimits.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAgentLLMConfigLimits1780700000000
+  implements MigrationInterface
+{
+  name = 'AddAgentLLMConfigLimits1780700000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "agent_llm_configs" ADD "maxOutputTokens" integer`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "agent_llm_configs" ADD "maxSteps" integer`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "agent_llm_configs" DROP COLUMN "maxSteps"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "agent_llm_configs" DROP COLUMN "maxOutputTokens"`,
+    );
+  }
+}

--- a/core-api/src/modules/agents/agents.completions.ts
+++ b/core-api/src/modules/agents/agents.completions.ts
@@ -79,7 +79,7 @@ export class AgentsCompletionsService {
   private readonly customToolSupportCache = new Map<string, boolean>();
   // Default context window (128k) - used for compaction threshold calculation
   private static readonly DEFAULT_CONTEXT_WINDOW = 128000;
-  private static readonly COMPACTION_THRESHOLD_RATIO = 0.7;
+  private static readonly COMPACTION_THRESHOLD_RATIO = 0.6;
 
   constructor(
     @InjectRepository(AgentLLMConfig)
@@ -392,7 +392,7 @@ export class AgentsCompletionsService {
         model,
         messages: [{ role: 'user', content: prompt }],
         tools,
-        stopWhen: stepCountIs(10),
+        stopWhen: stepCountIs(20),
         ...(() => {
           const opts = getReasoningProviderOptions(llmConfig.provider);
           return opts ? { providerOptions: opts } : {};
@@ -490,18 +490,21 @@ export class AgentsCompletionsService {
   }
 
   /**
-   * Fetches up to 20 most recent messages from the conversation, sorted chronologically.
-   * Used to build conversation context for the model.
+   * Fetches messages from the conversation for building context.
+   * When a summary exists, only recent messages are needed (old context is in summary).
    */
   private async getConversationHistory(
     conversationId: string,
+    hasSummary: boolean,
   ): Promise<AgentMessage[]> {
+    // If summary exists, only keep recent messages (old context is in summary)
+    const take = hasSummary ? 5 : 20;
     const messages = await this.messageRepository.find({
       where: { conversationId },
-      order: { createdAt: 'DESC' }, // Fetch newest first
-      take: 20,
+      order: { createdAt: 'DESC' },
+      take,
     });
-    return messages.reverse(); // Reverse to chronological order
+    return messages.reverse();
   }
 
   /**
@@ -952,10 +955,11 @@ export class AgentsCompletionsService {
       return { aiStream: emptyStream, conversationId, todosEmitter };
     }
 
-    // Determine max output tokens based on agent mode
+    // Determine max output tokens based on agent mode and LLM config
     // AGENT mode needs more tokens for multi-step tool execution
     const maxOutputTokens =
-      options.agentMode === AgentMode.AGENT ? 16384 : undefined;
+      llmConfig.maxOutputTokens ??
+      (options.agentMode === AgentMode.AGENT ? 32768 : undefined);
 
     // Invoke the AI SDK streamText with all callbacks
     const result = streamText({
@@ -964,7 +968,12 @@ export class AgentsCompletionsService {
       system: contextParts.join('\n\n'),
       messages: modelMessages,
       // Only include tools if available (models without tool support will error here)
-      ...(tools ? { tools, stopWhen: stepCountIs(10) } : {}),
+      ...(tools
+        ? {
+            tools,
+            stopWhen: stepCountIs(llmConfig.maxSteps ?? 20),
+          }
+        : {}),
       // Enable reasoning/thinking via provider-specific options
       ...(() => {
         const opts = getReasoningProviderOptions(llmConfig.provider);
@@ -982,7 +991,9 @@ export class AgentsCompletionsService {
       },
       // Handle errors (especially tool-calling errors)
       onError: ({ error }) => {
-        this.handleToolError(error, llmConfig);
+        // Log the error but don't throw — throwing in onError can crash the stream.
+        // Tool errors will be detected via toolResults in onFinish.
+        this.logger.error('[Agent] Stream error during execution', error);
       },
       // Pass abort signal so AI SDK can cancel the provider call
       abortSignal,
@@ -1138,7 +1149,7 @@ export class AgentsCompletionsService {
           return;
         }
         if (options.agentMode !== AgentMode.AGENT) {
-          this.autoCompleteStuckTodos(conversationId).catch((err) =>
+          await this.autoCompleteStuckTodos(conversationId).catch((err) =>
             this.logger.error('Error in autoCompleteStuckTodos', err),
           );
         }
@@ -1149,8 +1160,8 @@ export class AgentsCompletionsService {
         }
 
         // Asynchronously check and trigger compaction if needed
-        // Fire-and-forget: does not block the stream response
-        this.handlePostStreamCompaction(
+        // Await compaction to ensure summary is saved before continuation loop checks it
+        await this.handlePostStreamCompaction(
           conversationId,
           llmConfig,
           contextParts,
@@ -1283,14 +1294,19 @@ export class AgentsCompletionsService {
                 if (done || controllerClosed) break;
                 controller.enqueue(value);
               }
+
+              // Wait briefly for async onFinish operations (todo updates, DB writes) to settle
+              await new Promise((resolve) => setTimeout(resolve, 500));
             } catch (iterationError) {
               this.logger.error(
                 `[Continuation] Error in iteration ${iteration} for ${conversationId}`,
                 iterationError,
               );
-              // Break out of the loop but don't crash — the finally block
-              // will clean up, and autoCompleteStuckTodos runs below.
-              break;
+              // Don't break on non-fatal errors — try next iteration
+              // Only break if abort signal fired or controller is closed
+              if (abortSignal?.aborted || controllerClosed) break;
+              // For other errors, continue to next iteration
+              continue;
             }
 
             if (abortSignal?.aborted || controllerClosed) break;
@@ -1310,7 +1326,10 @@ export class AgentsCompletionsService {
 
             // Prepare next iteration context
             const updatedMessages =
-              await this.getConversationHistory(conversationId);
+              await this.getConversationHistory(
+                conversationId,
+                !!conversation?.summary,
+              );
             currentModelMessages =
               this.mapHistoryToModelMessages(updatedMessages);
 
@@ -1436,8 +1455,12 @@ export class AgentsCompletionsService {
     // Step 2: Save the user's message to DB
     await this.saveUserMessage(conversation.id, dto.question);
 
-    // Step 3: Fetch conversation history (up to 5 most recent messages)
-    const historyMessages = await this.getConversationHistory(conversation.id);
+    // Step 3: Fetch conversation history
+    // When summary exists, only recent messages needed (old context is in summary)
+    const historyMessages = await this.getConversationHistory(
+      conversation.id,
+      !!conversation.summary,
+    );
 
     // Step 4: Resolve the final LLM config with user overrides
     const llmConfig = await this.resolveLLMConfigWithOverrides(
@@ -1516,6 +1539,11 @@ export class AgentsCompletionsService {
         todosEmitter,
       ) as ToolSet),
       ...(loadSkillTool ? { load_skill: loadSkillTool } : {}),
+      // Add memory tools
+      ...(this.agentTool.getMemoryTools(
+        workspaceId,
+        conversation.id,
+      ) as ToolSet),
     };
 
     // Step 12: Build the combined stream with auto-continuation

--- a/core-api/src/modules/agents/agents.tools.ts
+++ b/core-api/src/modules/agents/agents.tools.ts
@@ -19,6 +19,7 @@ import { WorkersService } from '@/modules/workers/workers.service';
 
 import { SortOrder } from '@/common/dtos/get-many-base.dto';
 import { AgentMode } from '@/common/enums/enum';
+import { AgentsMemoriesService } from './agents.memories';
 import {
   detailAssetSchema,
   detailIssueSchema,
@@ -65,6 +66,7 @@ export class AgentTool {
     private readonly remoteExecuteService: RemoteExecuteService,
     @InjectRepository(AgentConversation)
     private readonly conversationRepository: Repository<AgentConversation>,
+    private readonly agentsMemories: AgentsMemoriesService,
   ) {}
 
   get getAssetsTool(): (workspaceId: string) => any {
@@ -395,13 +397,117 @@ export class AgentTool {
         steps: z.array(z.string().min(1)).min(1).describe('Plan steps'),
       }),
       execute: async (params: { steps: string[] }) => {
-        const now = new Date().toISOString();
-        const todos: AgentTodoItem[] = params.steps.map((step) => ({
-          id: randomUUID(), content: step, status: 'pending' as const, updatedAt: now,
-        }));
-        await repo.update(conversationId, { todos });
-        if (emitter) emitter.emit('todos-updated', todos);
-        return { success: true, message: `Plan set with ${todos.length} steps.`, todos };
+        try {
+          // Log raw params for debugging
+          console.log('[formulate_plan] Raw params:', JSON.stringify(params, null, 2));
+
+          // Normalize steps: handle various formats AI might send
+          let normalizedSteps: string[] = [];
+
+          const rawSteps = params.steps as string[] | string;
+
+          const cleanStep = (s: string): string => {
+            let cleaned = s.trim();
+            // Remove surrounding quotes (single or double)
+            if (
+              (cleaned.startsWith('"') && cleaned.endsWith('"')) ||
+              (cleaned.startsWith("'") && cleaned.endsWith("'"))
+            ) {
+              cleaned = cleaned.slice(1, -1).trim();
+            }
+            // Remove escaped quotes
+            cleaned = cleaned.replace(/\\"/g, '"').replace(/\\'/g, "'");
+            // Remove extra whitespace but preserve intentional newlines
+            cleaned = cleaned.replace(/[ \t]+/g, ' ').trim();
+            return cleaned;
+          };
+
+          // Try to parse as JSON array first (in case AI sends JSON string)
+          let stepsArray: string[] = [];
+          
+          if (typeof rawSteps === 'string') {
+            // Try JSON parse
+            try {
+              const parsed = JSON.parse(rawSteps);
+              if (Array.isArray(parsed)) {
+                stepsArray = parsed.map((s) => String(s));
+                console.log('[formulate_plan] Parsed from JSON string');
+              } else {
+                // Single string - use as is
+                stepsArray = [rawSteps];
+              }
+            } catch {
+              // Not valid JSON, treat as plain string
+              stepsArray = [rawSteps];
+            }
+          } else if (Array.isArray(rawSteps)) {
+            // Check if it's a JSON string inside array (e.g., ["[\"step1\", \"step2\"]"])
+            if (rawSteps.length === 1 && typeof rawSteps[0] === 'string') {
+              const first = rawSteps[0];
+              try {
+                const parsed = JSON.parse(first);
+                if (Array.isArray(parsed)) {
+                  stepsArray = parsed.map((s) => String(s));
+                  console.log('[formulate_plan] Parsed from nested JSON string');
+                } else {
+                  stepsArray = rawSteps;
+                }
+              } catch {
+                stepsArray = rawSteps;
+              }
+            } else {
+              stepsArray = rawSteps;
+            }
+          }
+
+          console.log('[formulate_plan] Steps array:', stepsArray);
+
+          // Clean each step
+          for (const s of stepsArray) {
+            if (typeof s === 'string' && s.trim()) {
+              const cleaned = cleanStep(s);
+              if (!cleaned) continue;
+
+              // Split by newline in case AI puts all steps in one string
+              if (cleaned.includes('\n')) {
+                const lines = cleaned
+                  .split('\n')
+                  .map((l) => cleanStep(l))
+                  .filter((l) => l.length > 0);
+                normalizedSteps.push(...lines);
+              } else {
+                normalizedSteps.push(cleaned);
+              }
+            } else if (typeof s === 'object' && s !== null) {
+              normalizedSteps.push(JSON.stringify(s));
+            } else if (s !== null && s !== undefined) {
+              const cleaned = cleanStep(String(s));
+              if (cleaned) normalizedSteps.push(cleaned);
+            }
+          }
+
+          console.log('[formulate_plan] Normalized steps:', normalizedSteps);
+          console.log('[formulate_plan] Normalized count:', normalizedSteps.length);
+
+          if (normalizedSteps.length === 0) {
+            return { success: false, message: 'No valid steps provided.' };
+          }
+
+          const now = new Date().toISOString();
+          const todos: AgentTodoItem[] = normalizedSteps.map((step) => ({
+            id: randomUUID(), content: step, status: 'pending' as const, updatedAt: now,
+          }));
+
+          console.log('[formulate_plan] Final todos:', JSON.stringify(todos, null, 2));
+
+          await repo.update(conversationId, { todos });
+          if (emitter) emitter.emit('todos-updated', todos);
+          return { success: true, message: `Plan set with ${todos.length} steps.`, todos };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          console.error('[formulate_plan] Error:', error);
+          return { success: false, message: `Failed to set plan: ${message}` };
+        }
       },
     };
 
@@ -412,18 +518,23 @@ export class AgentTool {
         status: z.enum(['pending', 'in_progress', 'completed', 'failed']).describe('New status'),
       }),
       execute: async (params: { id: string; status: AgentTodoItem['status'] }) => {
-        const conversation = await repo.findOne({ where: { id: conversationId } });
-        if (!conversation) return { success: false, message: 'Conversation not found' };
+        try {
+          const conversation = await repo.findOne({ where: { id: conversationId } });
+          if (!conversation) return { success: false, message: 'Conversation not found' };
 
-        const targetTodo = (conversation.todos ?? []).find((t) => t.id === params.id);
-        if (!targetTodo) return { success: false, message: `Todo "${params.id}" not found.` };
+          const targetTodo = (conversation.todos ?? []).find((t) => t.id === params.id);
+          if (!targetTodo) return { success: false, message: `Todo "${params.id}" not found.` };
 
-        const todos = (conversation.todos ?? []).map((t) =>
-          t.id === params.id ? { ...t, status: params.status, updatedAt: new Date().toISOString() } : t,
-        );
-        await repo.update(conversationId, { todos });
-        if (emitter) emitter.emit('todos-updated', todos);
-        return { success: true, message: `Updated "${targetTodo.content}" -> ${params.status}`, todo: todos.find((t) => t.id === params.id) };
+          const todos = (conversation.todos ?? []).map((t) =>
+            t.id === params.id ? { ...t, status: params.status, updatedAt: new Date().toISOString() } : t,
+          );
+          await repo.update(conversationId, { todos });
+          if (emitter) emitter.emit('todos-updated', todos);
+          return { success: true, message: `Updated "${targetTodo.content}" -> ${params.status}`, todo: todos.find((t) => t.id === params.id) };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return { success: false, message: `Failed to update step: ${message}` };
+        }
       },
     };
 
@@ -433,16 +544,21 @@ export class AgentTool {
         content: z.string().min(1).describe('Todo content'),
       }),
       execute: async (params: { content: string }) => {
-        const conversation = await repo.findOne({ where: { id: conversationId } });
-        if (!conversation) return { success: false, message: 'Conversation not found' };
+        try {
+          const conversation = await repo.findOne({ where: { id: conversationId } });
+          if (!conversation) return { success: false, message: 'Conversation not found' };
 
-        const now = new Date().toISOString();
-        const newTodo: AgentTodoItem = { id: randomUUID(), content: params.content, status: 'pending', updatedAt: now };
-        const todos = [...(conversation.todos ?? []), newTodo];
+          const now = new Date().toISOString();
+          const newTodo: AgentTodoItem = { id: randomUUID(), content: params.content, status: 'pending', updatedAt: now };
+          const todos = [...(conversation.todos ?? []), newTodo];
 
-        await repo.update(conversationId, { todos });
-        if (emitter) emitter.emit('todos-updated', todos);
-        return { success: true, message: `Added todo "${params.content}".`, todo: newTodo };
+          await repo.update(conversationId, { todos });
+          if (emitter) emitter.emit('todos-updated', todos);
+          return { success: true, message: `Added todo "${params.content}".`, todo: newTodo };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return { success: false, message: `Failed to add step: ${message}` };
+        }
       },
     };
 
@@ -450,9 +566,14 @@ export class AgentTool {
       description: 'Clear entire plan (irreversible). Then call formulate_plan to create a new one.',
       parameters: z.object({}),
       execute: async () => {
-        await repo.update(conversationId, { todos: [] });
-        if (emitter) emitter.emit('todos-updated', []);
-        return { success: true, message: 'Plan cleared.' };
+        try {
+          await repo.update(conversationId, { todos: [] });
+          if (emitter) emitter.emit('todos-updated', []);
+          return { success: true, message: 'Plan cleared.' };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return { success: false, message: `Failed to clear plan: ${message}` };
+        }
       },
     };
 
@@ -461,6 +582,169 @@ export class AgentTool {
       transition_step: tool(updateTodoStatusTool),
       append_step: tool(addTodoTool),
       scrap_plan: tool(clearPlanTool),
+    };
+  }
+
+  getMemoryTools(
+    workspaceId: string,
+    conversationId: string,
+  ): Record<string, ToolType> {
+    const memoriesService = this.agentsMemories;
+
+    const stmWriteTool: any = {
+      description:
+        'Save a key-value pair to short-term memory (conversation scope). ' +
+        'Use this to remember important findings during execution (e.g., discovered IPs, scan results, target info).',
+      parameters: z.object({
+        key: z
+          .string()
+          .min(1)
+          .describe(
+            'Memory key (e.g. "target_info", "open_ports", "scan_results")',
+          ),
+        value: z.string().min(1).describe('Memory value to store'),
+      }),
+      execute: async (params: { key: string; value: string }) => {
+        try {
+          await memoriesService.stmSet(
+            conversationId,
+            params.key,
+            params.value,
+          );
+          return {
+            success: true,
+            message: `Stored "${params.key}" in short-term memory.`,
+          };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return { success: false, message: `Failed to store memory: ${message}` };
+        }
+      },
+    };
+
+    const stmReadTool: any = {
+      description: 'Read a value from short-term memory by key.',
+      parameters: z.object({
+        key: z.string().describe('Memory key to read'),
+      }),
+      execute: async (params: { key: string }) => {
+        try {
+          const entry = await memoriesService.stmGet(
+            conversationId,
+            params.key,
+          );
+          if (!entry) {
+            return {
+              found: false,
+              message: `No memory found for key "${params.key}".`,
+            };
+          }
+          return {
+            found: true,
+            key: entry.key,
+            value: entry.value,
+            updatedAt: entry.updatedAt,
+          };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return { success: false, message: `Failed to read memory: ${message}` };
+        }
+      },
+    };
+
+    const stmListTool: any = {
+      description: 'List all short-term memory entries for this conversation.',
+      parameters: z.object({}),
+      execute: async () => {
+        try {
+          const entries = await memoriesService.stmGetAll(conversationId);
+          return {
+            count: entries.length,
+            entries: entries.map((e) => ({
+              key: e.key,
+              value: e.value,
+              updatedAt: e.updatedAt,
+            })),
+          };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return { success: false, message: `Failed to list memories: ${message}` };
+        }
+      },
+    };
+
+    const ltmWriteTool: any = {
+      description:
+        'Save important information to long-term memory (workspace scope, persists across conversations). ' +
+        'Use this for persistent knowledge like target profiles, known vulnerabilities, organizational policies.',
+      parameters: z.object({
+        content: z
+          .string()
+          .min(1)
+          .describe('Content to store in long-term memory'),
+      }),
+      execute: async (params: { content: string }) => {
+        try {
+          await memoriesService.ltmSet(workspaceId, params.content);
+          return {
+            success: true,
+            message: 'Saved to long-term memory.',
+          };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return { success: false, message: `Failed to save LTM: ${message}` };
+        }
+      },
+    };
+
+    const ltmAppendTool: any = {
+      description:
+        'Append information to existing long-term memory (keeps previous content).',
+      parameters: z.object({
+        content: z
+          .string()
+          .min(1)
+          .describe('Content to append to existing long-term memory'),
+      }),
+      execute: async (params: { content: string }) => {
+        try {
+          const existing = await memoriesService.ltmGet(workspaceId);
+          const newContent = existing.content
+            ? `${existing.content}\n\n${params.content}`
+            : params.content;
+          await memoriesService.ltmSet(workspaceId, newContent);
+          return {
+            success: true,
+            message: 'Appended to long-term memory.',
+          };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return { success: false, message: `Failed to append LTM: ${message}` };
+        }
+      },
+    };
+
+    const ltmReadTool: any = {
+      description: 'Read the current long-term memory content.',
+      parameters: z.object({}),
+      execute: async () => {
+        try {
+          const record = await memoriesService.ltmGet(workspaceId);
+          return { content: record.content || '(empty)' };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return { success: false, message: `Failed to read LTM: ${message}` };
+        }
+      },
+    };
+
+    return {
+      stm_write: tool(stmWriteTool),
+      stm_read: tool(stmReadTool),
+      stm_list: tool(stmListTool),
+      ltm_write: tool(ltmWriteTool),
+      ltm_append: tool(ltmAppendTool),
+      ltm_read: tool(ltmReadTool),
     };
   }
 

--- a/core-api/src/modules/agents/entities/agent-llm-config.entity.ts
+++ b/core-api/src/modules/agents/entities/agent-llm-config.entity.ts
@@ -4,6 +4,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import {
   IsBoolean,
   IsEnum,
+  IsNumber,
   IsOptional,
   IsString,
   IsUUID,
@@ -67,4 +68,22 @@ export class AgentLLMConfig extends BaseEntity {
   @IsUUID()
   @Column({ type: 'uuid' })
   createdBy: string;
+
+  @ApiProperty({
+    description: 'Max output tokens for agent mode',
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Column({ type: 'int', nullable: true })
+  maxOutputTokens?: number;
+
+  @ApiProperty({
+    description: 'Max tool call steps per iteration',
+    required: false,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Column({ type: 'int', nullable: true })
+  maxSteps?: number;
 }

--- a/core-api/src/modules/agents/prompts/AGENT.md
+++ b/core-api/src/modules/agents/prompts/AGENT.md
@@ -51,6 +51,13 @@ Agent: [calls formulate_plan with the steps]
 
 After the user confirms, use `formulate_plan` to break the approved plan into sequential, actionable steps.
 
+**IMPORTANT**: When calling `formulate_plan`, pass steps as an ARRAY of strings:
+```
+formulate_plan(steps: ["Step 1 description", "Step 2 description", "Step 3 description"])
+```
+
+Each step should be a SEPARATE string in the array. Do NOT put all steps in a single string.
+
 ### Step 2: Execute Step by Step
 
 Work through each step in order:
@@ -90,6 +97,34 @@ OASM entities: Assets (domains, IPs, services), Vulnerabilities, Technologies, J
 4. Web search — when no direct URL is known
 
 If data is unavailable after all efforts: state clearly, give best-effort guidance, suggest next steps (run scans, expand scope).
+
+## Critical Execution Rules
+
+### NEVER STOP MID-PLAN (HIGHEST PRIORITY)
+- Once you start executing a plan, you MUST continue until ALL steps are completed
+- Do NOT output text between steps unless absolutely necessary (1 sentence max)
+- Do NOT ask for confirmation mid-plan — just execute
+- If a step fails, try 2 alternative approaches before marking as failed, then continue to next step
+- ALL STEPS MUST BE EXECUTED IN A SINGLE RESPONSE
+
+### Handling New User Requests During Active Plan
+- **IGNORE new requests** while a plan is in progress — complete the current plan FIRST
+- After finishing, acknowledge the new request and start a new plan if needed
+- The ONLY exception: user explicitly says "STOP" or "CANCEL" — then you may halt
+- Never abandon a partially-completed plan
+
+### Todo State Management
+- BEFORE starting work on a step: call `transition_step(id, "in_progress")`
+- AFTER completing a step: call `transition_step(id, "completed")` IMMEDIATELY
+- If a step fails after retries: call `transition_step(id, "failed")`
+- NEVER leave a step in "in_progress" state when you're done with it
+
+### Memory Usage
+- Use `stm_write(key, value)` to save important findings during execution (e.g., discovered IPs, open ports, scan results)
+- Use `stm_read(key)` to recall previous findings when needed
+- Use `stm_list()` to see all stored short-term memories
+- Use `ltm_write(content)` to persist critical workspace-level knowledge across conversations
+- Use `ltm_append(content)` to add to existing long-term memory without overwriting
 
 ## Response Structure
 

--- a/core-api/src/modules/agents/prompts/SYSTEM.md
+++ b/core-api/src/modules/agents/prompts/SYSTEM.md
@@ -27,9 +27,31 @@ OASM entities: Assets (domains, IPs, services), Vulnerabilities, Technologies, J
 
 If data is unavailable after all efforts: state clearly, give best-effort guidance, suggest next steps (run scans, expand scope).
 
+## Memory System
+
+### Short-Term Memory (STM)
+- **Scope:** Current conversation only (expires after 24 hours)
+- `stm_write(key, value)` — Save a finding with a descriptive key
+- `stm_read(key)` — Recall a specific finding
+- `stm_list()` — See all stored memories
+- Use during execution to track discoveries across tool calls
+
+### Long-Term Memory (LTM)
+- **Scope:** Entire workspace, persists across conversations
+- `ltm_write(content)` — Save/overwrite workspace knowledge
+- `ltm_append(content)` — Add to existing knowledge
+- `ltm_read()` — Check current LTM content
+- Use for persistent information: target profiles, known issues, org policies
+
 ## Tool Usage Rules
 - Never expose internal tool names. Say "I found X assets" not "get_assets returned".
 - Focus on results and insights, not the mechanism.
+
+## Plan Execution Rules (CRITICAL)
+- Once a plan is created, you MUST execute ALL steps without stopping
+- Complete the current plan before addressing any new user request
+- If user sends a new request mid-plan, finish current plan first, then respond
+- Only stop if user explicitly says "STOP" or "CANCEL"
 
 ### CVE Lookup
 Fetch from: `https://raw.githubusercontent.com/trickest/cve/refs/heads/main/{YEAR}/CVE-{YEAR}-{NUMBER}.md`


### PR DESCRIPTION
- Fix auto-compact: getConversationHistory respects summary (5 vs 20 messages)
- Fix shouldCompact threshold from 70% to 60% for more conservative compaction
- Make handlePostStreamCompaction awaitable in onFinish callback
- Increase maxOutputTokens from 16384 to 32768 for AGENT mode
- Increase stepCountIs limit from 10 to 20 per iteration
- Add error recovery in continuation loop (continue on non-fatal errors)
- Fix onError callback to log instead of throw
- Add 500ms delay before todo state check to avoid race conditions
- Make autoCompleteStuckTodos awaitable in non-Agent mode
- Add 6 memory tools (stm_write/read/list, ltm_write/append/read)
- Add configurable maxOutputTokens/maxSteps to LLM config entity
- Create migration for new agent_llm_configs columns
- Update AGENT.md with stricter execution rules and memory usage
- Update SYSTEM.md with memory system documentation
- Fix formulate_plan tool to parse JSON string steps correctly
- Fix React infinite re-render loop in use-agent-chat hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable output token and step limits for agent execution.
  * Introduced short-term and long-term memory capabilities for agents to record and recall findings.

* **Improvements**
  * Enhanced agent streaming behavior and context management for better performance.
  * Improved agent plan execution enforcement with clearer execution rules.
  * Better error handling in agent tools for more robust operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->