### PR TITLE
feat(agents): add workspace memory system with user-scoped memories and improved MCP config

### DIFF
--- a/console/src/components/agent-settings-dialog.tsx
+++ b/console/src/components/agent-settings-dialog.tsx
@@ -1,13 +1,13 @@
 import LlmConnect from '@/components/llm-connect';
-import { MCPServersManager } from '@/components/mcp-servers-manager';
+import { MemoryManager } from '@/components/memory-manager';
 import { SkillsManager } from '@/components/skills-manager';
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { BookOpen, KeyRound, Server } from 'lucide-react';
+import { BookOpen, Brain, KeyRound } from 'lucide-react';
 import { type ComponentType, type SVGProps } from 'react';
 
 interface TabConfig {
-  value: 'provider' | 'mcp' | 'skills';
+  value: 'provider' | 'skills' | 'memory';
   label: string;
   description: string;
   icon: ComponentType<SVGProps<SVGSVGElement>>;
@@ -23,18 +23,18 @@ const tabs: TabConfig[] = [
     component: LlmConnect,
   },
   {
-    value: 'mcp',
-    label: 'MCP Servers',
-    description: 'Extend agent capabilities with external MCP servers',
-    icon: Server,
-    component: MCPServersManager,
-  },
-  {
     value: 'skills',
     label: 'Skills',
     description: 'Specialized instructions the agent can use to perform tasks',
     icon: BookOpen,
     component: SkillsManager,
+  },
+  {
+    value: 'memory',
+    label: 'Memory',
+    description: 'Long-term memory content used by the AI agent',
+    icon: Brain,
+    component: MemoryManager,
   },
 ];
 
@@ -44,7 +44,7 @@ const triggerClassName =
 interface AgentSettingsDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  defaultTab?: 'provider' | 'mcp' | 'skills';
+  defaultTab?: 'provider' | 'skills' | 'memory';
 }
 
 export function AgentSettingsDialog({

--- a/console/src/components/mcp-servers-manager.tsx
+++ b/console/src/components/mcp-servers-manager.tsx
@@ -2,6 +2,8 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Label } from '@/components/ui/label';
 import { useWorkspaceState } from '@/hooks/useWorkspaceSelector';
 import type {
   MCPServerConfigDto,
@@ -23,92 +25,42 @@ import {
   Plus,
   RefreshCw,
   Server,
-  Terminal,
   Trash2,
-  Wifi,
+  X,
 } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useFieldArray, useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
 import { cn } from '@/lib/utils';
 
 const MCP_QUERY_KEY = '/api/agents/mcp-configs';
 
-type TransportType = 'sse' | 'stdio';
 type MCPServerStatus = 'checking' | 'online' | 'offline' | 'unknown';
 
-const serverSchema = z
-  .object({
-    name: z
-      .string()
-      .min(1, 'Server name is required')
-      .regex(
-        /^[a-z0-9-_]+$/i,
-        'Only letters, numbers, hyphens and underscores',
-      ),
-    transport: z.enum(['sse', 'stdio']),
-    url: z.string().optional(),
-    command: z.string().optional(),
-    args: z.string().optional(),
-    apiKey: z.string().optional(),
-    timeout: z.coerce.number().min(1),
-  })
-  .superRefine((data, ctx) => {
-    if (data.transport === 'sse' && !data.url) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['url'],
-        message: 'URL is required for SSE transport',
-      });
-    }
-    if (data.transport === 'stdio' && !data.command) {
-      ctx.addIssue({
-        code: 'custom',
-        path: ['command'],
-        message: 'Command is required for stdio transport',
-      });
-    }
-  });
+const serverSchema = z.object({
+  name: z
+    .string()
+    .min(1, 'Server name is required')
+    .regex(
+      /^[a-z0-9-_]+$/i,
+      'Only letters, numbers, hyphens and underscores',
+    ),
+  url: z.string().url('URL is required'),
+  transport: z.enum(['sse', 'streamable-http']).default('sse'),
+  headers: z
+    .array(
+      z.object({
+        key: z.string().min(1),
+        value: z.string().min(1),
+      }),
+    )
+    .optional(),
+  timeout: z.coerce.number().min(1),
+  sseReadTimeout: z.coerce.number().min(1).default(300),
+});
 
 type ServerFormData = z.input<typeof serverSchema>;
-
-function parseArgs(input: string): string[] {
-  const args: string[] = [];
-  let current = '';
-  let inQuotes = false;
-  let quoteChar = '';
-
-  for (let i = 0; i < input.length; i++) {
-    const char = input[i];
-    if ((char === '"' || char === "'") && (i === 0 || input[i - 1] !== '\\')) {
-      if (inQuotes) {
-        if (char === quoteChar) {
-          inQuotes = false;
-          quoteChar = '';
-        } else {
-          current += char;
-        }
-      } else {
-        inQuotes = true;
-        quoteChar = char;
-      }
-    } else if (char === ' ' && !inQuotes) {
-      if (current) {
-        args.push(current);
-        current = '';
-      }
-    } else {
-      current += char;
-    }
-  }
-  if (current) args.push(current);
-  return args;
-}
-
-function detectTransport(server: MCPServerResponseDto): TransportType {
-  return server.url ? 'sse' : 'stdio';
-}
 
 function StatusDot({ status }: { status: MCPServerStatus }) {
   if (status === 'checking') {
@@ -135,7 +87,7 @@ function StatusDot({ status }: { status: MCPServerStatus }) {
     unknown: {
       bg: 'bg-slate-500/50',
       shadow: '',
-      label: 'Status unknown (stdio)',
+      label: 'Unknown',
     },
   };
 
@@ -169,20 +121,29 @@ function AddServerForm({
   onCancel: () => void;
 }) {
   const queryClient = useQueryClient();
-  const [transport, setTransport] = useState<TransportType>('sse');
 
   const {
     register,
     handleSubmit,
+    control,
     watch,
-    setValue,
     formState: { errors },
   } = useForm<ServerFormData>({
     resolver: zodResolver(serverSchema),
-    defaultValues: { transport: 'sse', timeout: 60 },
+    defaultValues: {
+      transport: 'sse',
+      timeout: 60,
+      sseReadTimeout: 300,
+      headers: [],
+    },
   });
 
-  const currentTransport = watch('transport');
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: 'headers',
+  });
+
+  const transportValue = watch('transport');
 
   const upsert = useAgentsControllerUpsertMCPServer({
     mutation: {
@@ -197,23 +158,28 @@ function AddServerForm({
 
   const onSubmit = (data: ServerFormData) => {
     const config: MCPServerConfigDto = {
+      url: data.url,
+      transport: data.transport,
       timeout: data.timeout,
+      sse_read_timeout: data.sseReadTimeout,
       disabled: false,
     };
-    if (data.transport === 'sse') {
-      config.url = data.url;
-      if (data.apiKey?.trim())
-        config.headers = { 'api-key': data.apiKey.trim() };
-    } else {
-      config.command = data.command;
-      config.args = data.args ? parseArgs(data.args) : [];
-    }
-    upsert.mutate({ name: data.name, data: config });
-  };
 
-  const handleTransportChange = (t: TransportType) => {
-    setTransport(t);
-    setValue('transport', t);
+    const headers: Record<string, string> = {};
+
+    if (data.headers && data.headers.length > 0) {
+      for (const h of data.headers) {
+        if (h.key.trim() && h.value.trim()) {
+          headers[h.key.trim()] = h.value.trim();
+        }
+      }
+    }
+
+    if (Object.keys(headers).length > 0) {
+      config.headers = headers;
+    }
+
+    upsert.mutate({ name: data.name, data: config });
   };
 
   return (
@@ -228,104 +194,130 @@ function AddServerForm({
         </span>
       </div>
 
-      <div className="flex p-1 bg-muted/50 rounded-lg w-fit border border-border/50">
-        {(['sse', 'stdio'] as TransportType[]).map((t) => (
-          <button
-            key={t}
-            type="button"
-            onClick={() => handleTransportChange(t)}
-            className={cn(
-              'flex items-center gap-2 px-4 py-1.5 rounded-md text-xs font-semibold transition-all duration-200',
-              currentTransport === t
-                ? 'bg-background text-foreground shadow-sm'
-                : 'text-muted-foreground hover:text-foreground hover:bg-background/50',
-            )}
-          >
-            {t === 'sse' ? (
-              <Wifi className={cn('size-3.5', currentTransport === t && 'text-blue-500')} />
-            ) : (
-              <Terminal className={cn('size-3.5', currentTransport === t && 'text-amber-500')} />
-            )}
-            {t === 'sse' ? 'SSE / HTTP' : 'stdio'}
-          </button>
-        ))}
-      </div>
-
-      <input type="hidden" {...register('transport')} value={transport} />
-
       <div className="grid gap-3">
         <div className="space-y-1">
           <label className="text-[10px] font-bold text-muted-foreground uppercase ml-1">Server Name</label>
           <Input
             {...register('name')}
-            placeholder="e.g. filesystem-server"
+            placeholder="e.g. my-mcp-server"
             error={errors.name?.message}
             className="bg-background/50 h-10"
           />
         </div>
 
-        {currentTransport === 'sse' && (
-          <>
-            <div className="space-y-1">
-              <label className="text-[10px] font-bold text-muted-foreground uppercase ml-1">Endpoint URL</label>
-              <Input
-                {...register('url')}
-                type="url"
-                placeholder="https://mcp.example.com/sse"
-                error={errors.url?.message}
-                className="bg-background/50 h-10 font-mono text-xs"
-              />
-            </div>
-            <div className="space-y-1">
-              <label className="text-[10px] font-bold text-muted-foreground uppercase ml-1">API Key (Optional)</label>
-              <Input
-                {...register('apiKey')}
-                type="password"
-                placeholder="••••••••••••••••"
-                autoComplete="new-password"
-                className="bg-background/50 h-10"
-              />
-            </div>
-          </>
-        )}
+        <div className="space-y-1">
+          <label className="text-[10px] font-bold text-muted-foreground uppercase ml-1">Endpoint URL</label>
+          <Input
+            {...register('url')}
+            type="url"
+            placeholder="https://mcp.example.com/sse"
+            error={errors.url?.message}
+            className="bg-background/50 h-10 font-mono text-xs"
+          />
+        </div>
 
-        {currentTransport === 'stdio' && (
-          <>
-            <div className="space-y-1">
-              <label className="text-[10px] font-bold text-muted-foreground uppercase ml-1">Command</label>
-              <Input
-                {...register('command')}
-                placeholder="npx"
-                error={errors.command?.message}
-                className="bg-background/50 h-10 font-mono text-xs"
-              />
+        <div className="space-y-2">
+          <label className="text-[10px] font-bold text-muted-foreground uppercase ml-1">Transport Type</label>
+          <RadioGroup
+            value={transportValue}
+            onValueChange={(val) => {
+              const event = { target: { name: 'transport', value: val } };
+              register('transport').onChange(event);
+            }}
+            className="flex gap-4"
+          >
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="sse" id="transport-sse" />
+              <Label htmlFor="transport-sse" className="text-sm font-medium cursor-pointer">
+                Server-Sent Events
+              </Label>
             </div>
-            <div className="space-y-1">
-              <label className="text-[10px] font-bold text-muted-foreground uppercase ml-1">Arguments</label>
-              <Input
-                {...register('args')}
-                placeholder="-y @modelcontextprotocol/server-filesystem /path"
-                className="bg-background/50 h-10 font-mono text-xs"
-              />
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="streamable-http" id="transport-streamable" />
+              <Label htmlFor="transport-streamable" className="text-sm font-medium cursor-pointer">
+                Streamable HTTP
+              </Label>
             </div>
-          </>
-        )}
+          </RadioGroup>
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <label className="text-[10px] font-bold text-muted-foreground uppercase ml-1">Custom Headers</label>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => append({ key: '', value: '' })}
+              className="h-6 text-xs"
+            >
+              <Plus className="size-3 mr-1" />
+              Add
+            </Button>
+          </div>
+          {fields.length > 0 && (
+            <div className="space-y-2">
+              {fields.map((field, index) => (
+                <div key={field.id} className="flex items-center gap-2">
+                  <Input
+                    {...register(`headers.${index}.key`)}
+                    placeholder="Key"
+                    className="h-8 text-xs font-mono bg-background/50"
+                  />
+                  <Input
+                    {...register(`headers.${index}.value`)}
+                    placeholder="Value"
+                    className="h-8 text-xs font-mono bg-background/50"
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    onClick={() => remove(index)}
+                    className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
+                  >
+                    <X className="size-3" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
       </div>
 
       <div className="flex items-center justify-between pt-2 border-t border-border/50">
-        <div className="flex items-center gap-3">
-          <label className="text-[10px] font-bold text-muted-foreground uppercase ml-1">
-            Timeout
-          </label>
+        <div className="flex items-center gap-4">
           <div className="flex items-center gap-2">
-            <Input
-              {...register('timeout')}
-              type="number"
-              min={1}
-              className="w-20 h-8 text-xs bg-background/50"
-            />
-            <span className="text-[10px] text-muted-foreground">seconds</span>
+            <label className="text-[10px] font-bold text-muted-foreground uppercase ml-1">
+              Timeout
+            </label>
+            <div className="flex items-center gap-2">
+              <Input
+                {...register('timeout')}
+                type="number"
+                min={1}
+                className="w-20 h-8 text-xs bg-background/50"
+              />
+              <span className="text-[10px] text-muted-foreground">seconds</span>
+            </div>
           </div>
+
+          {transportValue === 'sse' && (
+            <div className="flex items-center gap-2">
+              <label className="text-[10px] font-bold text-muted-foreground uppercase ml-1">
+                SSE Read Timeout
+              </label>
+              <div className="flex items-center gap-2">
+                <Input
+                  {...register('sseReadTimeout')}
+                  type="number"
+                  min={1}
+                  className="w-20 h-8 text-xs bg-background/50"
+                />
+                <span className="text-[10px] text-muted-foreground">seconds</span>
+              </div>
+            </div>
+          )}
         </div>
 
         <div className="flex justify-end gap-2">
@@ -359,7 +351,6 @@ function ServerRow({
 }) {
   const queryClient = useQueryClient();
   const [expanded, setExpanded] = useState(false);
-  const transport = detectTransport(server);
 
   const toggle = useAgentsControllerToggleMCPServer({
     mutation: {
@@ -415,9 +406,7 @@ function ServerRow({
             )}
           </div>
           <p className="text-xs font-mono text-muted-foreground/60 truncate selection:bg-primary/10">
-            {transport === 'sse'
-              ? server.url
-              : `${server.command ?? ''} ${(server.args ?? []).join(' ')}`}
+            {server.url}
           </p>
         </div>
 
@@ -475,23 +464,18 @@ function ServerRow({
       </div>
 
       {expanded && (
-        <div className={cn(
-          "border-t px-4 py-3 space-y-2 text-[11px] animate-in fade-in slide-in-from-top-1 duration-200",
-          transport === 'sse' ? "bg-blue-500/[0.04] dark:bg-blue-500/[0.02]" : "bg-amber-500/[0.04] dark:bg-amber-500/[0.02]"
-        )}>
+        <div className="border-t px-4 py-3 space-y-2 text-[11px] animate-in fade-in slide-in-from-top-1 duration-200 bg-blue-500/[0.04] dark:bg-blue-500/[0.02]">
           {server.url && (
             <div className="flex gap-4">
               <span className="text-[10px] font-bold text-muted-foreground uppercase w-20 shrink-0">URL</span>
               <span className="truncate font-mono text-muted-foreground/90 selection:bg-primary/20">{server.url}</span>
             </div>
           )}
-          {server.command && (
+          {server.transport && (
             <div className="flex gap-4">
-              <span className="text-[10px] font-bold text-muted-foreground uppercase w-20 shrink-0">
-                Command
-              </span>
-              <span className="font-mono text-muted-foreground/90 selection:bg-primary/20">
-                {server.command} {(server.args ?? []).join(' ')}
+              <span className="text-[10px] font-bold text-muted-foreground uppercase w-20 shrink-0">Transport</span>
+              <span className="font-mono text-muted-foreground/90 uppercase tracking-wider text-[10px]">
+                {server.transport === 'streamable-http' ? 'Streamable HTTP' : 'SSE'}
               </span>
             </div>
           )}
@@ -522,6 +506,12 @@ function ServerRow({
             <span className="text-[10px] font-bold text-muted-foreground uppercase w-20 shrink-0">Timeout</span>
             <span className="text-muted-foreground/90 font-semibold">{server.timeout ?? 60}s</span>
           </div>
+          {server.transport === 'sse' && (
+            <div className="flex gap-4">
+              <span className="text-[10px] font-bold text-muted-foreground uppercase w-20 shrink-0">SSE Read Timeout</span>
+              <span className="text-muted-foreground/90 font-semibold">{server.sse_read_timeout ?? 300}s</span>
+            </div>
+          )}
           <div className="flex gap-4">
             <span className="text-[10px] font-bold text-muted-foreground uppercase w-20 shrink-0">Status</span>
             <span
@@ -597,14 +587,12 @@ export function MCPServersManager() {
   // Keep ref up-to-date with the latest callback
   pingServerRef.current = pingServer;
 
-  // Auto-ping all enabled SSE servers when server list changes
+  // Auto-ping all enabled servers when server list changes
   useEffect(() => {
     if (!servers.length) return;
     for (const server of servers) {
       if (!server.disabled && server.url) {
         void pingServerRef.current(server.name);
-      } else if (!server.url) {
-        setStatuses((prev) => ({ ...prev, [server.name]: 'unknown' }));
       }
     }
     // pingServerRef is a ref — always current, safe to omit

--- a/console/src/components/memory-manager.tsx
+++ b/console/src/components/memory-manager.tsx
@@ -1,0 +1,156 @@
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
+import { Button } from '@/components/ui/button';
+import { useWorkspaceState } from '@/hooks/useWorkspaceSelector';
+import {
+  useAgentsControllerDeleteWorkspaceMemory,
+  useAgentsControllerGetWorkspaceMemory,
+} from '@/services/apis/gen/queries';
+import { ChevronDown, Loader2, RefreshCw, Trash2 } from 'lucide-react';
+import { useCallback, useState } from 'react';
+import { cn } from '@/lib/utils';
+
+const PREVIEW_LINES = 3;
+
+function MemoryItem({
+  memory,
+  onDelete,
+}: {
+  memory: { id: string; content: string; updatedAt: string };
+  onDelete: (id: string) => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const lines = memory.content.split('\n');
+  const isLong = lines.length > PREVIEW_LINES;
+
+  return (
+    <div className="rounded-xl border bg-card/50 backdrop-blur-sm p-4">
+      <pre className="text-sm text-muted-foreground whitespace-pre-wrap font-mono leading-relaxed">
+        {expanded ? memory.content : lines.slice(0, PREVIEW_LINES).join('\n')}
+      </pre>
+      <div className="flex items-center justify-between mt-2">
+        <div className="flex items-center gap-2">
+          {isLong && (
+            <button
+              onClick={() => setExpanded((prev) => !prev)}
+              className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <ChevronDown
+                className={cn(
+                  'size-3 transition-transform',
+                  expanded && 'rotate-180',
+                )}
+              />
+              {expanded ? 'Show less' : 'Show more'}
+            </button>
+          )}
+          <p className="text-[10px] text-muted-foreground/60">
+            {new Date(memory.updatedAt).toLocaleString()}
+          </p>
+        </div>
+        <ConfirmDialog
+          title="Delete memory"
+          description="Are you sure you want to delete this memory record? This action cannot be undone."
+          onConfirm={() => onDelete(memory.id)}
+          trigger={
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-7 text-muted-foreground hover:text-destructive"
+            >
+              <Trash2 className="size-3.5" />
+            </Button>
+          }
+          confirmText="Delete"
+        />
+      </div>
+    </div>
+  );
+}
+
+export function MemoryManager() {
+  const {
+    state: { selectedWorkspaceId },
+  } = useWorkspaceState();
+
+  const { data, isLoading, refetch, isFetching } =
+    useAgentsControllerGetWorkspaceMemory({
+      query: {
+        queryKey: ['/api/agents/workspace-memory'],
+        enabled: !!selectedWorkspaceId,
+      },
+    });
+
+  const deleteMutation = useAgentsControllerDeleteWorkspaceMemory({
+    mutation: {
+      onSuccess: () => {
+        void refetch();
+      },
+    },
+  });
+
+  const memories = data?.data ?? [];
+
+  const handleRefresh = useCallback(() => {
+    void refetch();
+  }, [refetch]);
+
+  const handleDelete = useCallback(
+    (id: string) => {
+      deleteMutation.mutate({ id });
+    },
+    [deleteMutation],
+  );
+
+  if (!selectedWorkspaceId) return null;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          Long-term memory content used by the AI agent
+        </p>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={handleRefresh}
+          className="gap-1.5"
+        >
+          {isFetching ? (
+            <Loader2 className="size-3.5 animate-spin" />
+          ) : (
+            <RefreshCw className="size-3.5" />
+          )}
+          Refresh
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-2">
+          {[1, 2].map((i) => (
+            <div
+              key={i}
+              className="h-24 rounded-lg border animate-pulse bg-muted/30"
+            />
+          ))}
+        </div>
+      ) : memories.length === 0 ? (
+        <div className="rounded-xl border border-dashed p-6 text-center">
+          <p className="text-sm text-muted-foreground">
+            No memory content yet. The AI agent will automatically store
+            important information here.
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {memories.map((memory) => (
+            <MemoryItem
+              key={memory.id}
+              memory={memory}
+              onDelete={handleDelete}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/console/src/components/memory-manager.tsx
+++ b/console/src/components/memory-manager.tsx
@@ -73,9 +73,8 @@ export function MemoryManager() {
   } = useWorkspaceState();
 
   const { data, isLoading, refetch, isFetching } =
-    useAgentsControllerGetWorkspaceMemory({
+    useAgentsControllerGetWorkspaceMemory(undefined, {
       query: {
-        queryKey: ['/api/agents/workspace-memory'],
         enabled: !!selectedWorkspaceId,
       },
     });

--- a/console/src/components/skills-manager.tsx
+++ b/console/src/components/skills-manager.tsx
@@ -11,6 +11,7 @@ import {
   DialogTitle,
   DialogDescription,
 } from '@/components/ui/dialog';
+import { Markdown } from '@/components/common/markdown';
 import { useQueryClient } from '@tanstack/react-query';
 import { useWorkspaceState } from '@/hooks/useWorkspaceSelector';
 import type {
@@ -27,6 +28,7 @@ import {
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
   BookOpen,
+  ChevronDown,
   Loader2,
   Pencil,
   Plus,
@@ -194,6 +196,7 @@ function SkillRow({
 }) {
   const queryClient = useQueryClient();
   const isBuiltin = skill.isBuiltin;
+  const [expanded, setExpanded] = useState(false);
 
   const toggle = useAgentsControllerToggleSkill({
     mutation: {
@@ -225,31 +228,37 @@ function SkillRow({
   return (
     <div className="group relative rounded-xl border bg-card transition-all duration-200 hover:shadow-md hover:border-border/80 overflow-hidden">
       <div className="flex items-center gap-3 p-4">
-        <div className={cn(
-          'relative flex items-center justify-center size-10 rounded-xl shrink-0 transition-all duration-300',
-          'bg-primary/10 text-primary dark:bg-primary/5 dark:text-primary group-hover:bg-primary/20 dark:group-hover:bg-primary/10',
-        )}>
-          <BookOpen className="size-5" />
-        </div>
-
-        <div className="flex-1 min-w-0 space-y-0.5">
-          <div className="flex items-center gap-2">
-            <p className="text-sm font-semibold tracking-tight truncate">{skill.name}</p>
-            {isBuiltin && (
-              <span className="text-[10px] font-bold px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground uppercase tracking-wider">
-                System
-              </span>
-            )}
-            {!isBuiltin && !skill.isEnabled && (
-              <span className="text-[10px] font-bold px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground uppercase tracking-wider">
-                Disabled
-              </span>
-            )}
+        <button
+          type="button"
+          className="flex items-center gap-3 flex-1 min-w-0 text-left"
+          onClick={() => setExpanded((prev) => !prev)}
+        >
+          <div className="flex-1 min-w-0 space-y-0.5">
+            <div className="flex items-center gap-2">
+              <p className="text-sm font-semibold tracking-tight truncate">{skill.name}</p>
+              {isBuiltin && (
+                <span className="text-[10px] font-bold px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground uppercase tracking-wider">
+                  System
+                </span>
+              )}
+              {!isBuiltin && !skill.isEnabled && (
+                <span className="text-[10px] font-bold px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground uppercase tracking-wider">
+                  Disabled
+                </span>
+              )}
+            </div>
+            <p className="text-xs text-muted-foreground/70 truncate selection:bg-primary/10">
+              {skill.description}
+            </p>
           </div>
-          <p className="text-xs text-muted-foreground/70 truncate selection:bg-primary/10">
-            {skill.description}
-          </p>
-        </div>
+
+          <ChevronDown
+            className={cn(
+              'size-4 text-muted-foreground transition-transform shrink-0',
+              expanded && 'rotate-180',
+            )}
+          />
+        </button>
 
         <div className="flex items-center gap-1 shrink-0">
           <div className="px-2 h-8 flex items-center">
@@ -292,6 +301,12 @@ function SkillRow({
           )}
         </div>
       </div>
+
+      {expanded && skill.content && (
+        <div className="border-t px-4 py-3 text-sm text-muted-foreground">
+          <Markdown content={skill.content} />
+        </div>
+      )}
     </div>
   );
 }

--- a/console/src/services/apis/gen/queries.ts
+++ b/console/src/services/apis/gen/queries.ts
@@ -1575,9 +1575,15 @@ export type SendMessageDto = {
   agentMode?: SendMessageDtoAgentMode;
 };
 
-export type MCPServerResponseDtoHeaders = { [key: string]: unknown };
+export type MCPServerResponseDtoTransport =
+  (typeof MCPServerResponseDtoTransport)[keyof typeof MCPServerResponseDtoTransport];
 
-export type MCPServerResponseDtoEnv = { [key: string]: unknown };
+export const MCPServerResponseDtoTransport = {
+  sse: 'sse',
+  'streamable-http': 'streamable-http',
+} as const;
+
+export type MCPServerResponseDtoHeaders = { [key: string]: unknown };
 
 /**
  * @nullable
@@ -1588,14 +1594,14 @@ export type MCPServerResponseDtoAllowedTools = {
 
 export type MCPServerResponseDto = {
   url?: string;
+  transport?: MCPServerResponseDtoTransport;
   headers?: MCPServerResponseDtoHeaders;
-  command?: string;
-  args?: string[];
-  env?: MCPServerResponseDtoEnv;
   disabled?: boolean;
   /** @nullable */
   allowed_tools?: MCPServerResponseDtoAllowedTools;
   timeout?: number;
+  /** SSE read timeout in seconds */
+  sse_read_timeout?: number;
   name: string;
 };
 
@@ -1603,9 +1609,15 @@ export type MCPConfigResponseDto = {
   servers: MCPServerResponseDto[];
 };
 
-export type MCPServerConfigDtoHeaders = { [key: string]: unknown };
+export type MCPServerConfigDtoTransport =
+  (typeof MCPServerConfigDtoTransport)[keyof typeof MCPServerConfigDtoTransport];
 
-export type MCPServerConfigDtoEnv = { [key: string]: unknown };
+export const MCPServerConfigDtoTransport = {
+  sse: 'sse',
+  'streamable-http': 'streamable-http',
+} as const;
+
+export type MCPServerConfigDtoHeaders = { [key: string]: unknown };
 
 /**
  * @nullable
@@ -1614,14 +1626,14 @@ export type MCPServerConfigDtoAllowedTools = { [key: string]: unknown } | null;
 
 export type MCPServerConfigDto = {
   url?: string;
+  transport?: MCPServerConfigDtoTransport;
   headers?: MCPServerConfigDtoHeaders;
-  command?: string;
-  args?: string[];
-  env?: MCPServerConfigDtoEnv;
   disabled?: boolean;
   /** @nullable */
   allowed_tools?: MCPServerConfigDtoAllowedTools;
   timeout?: number;
+  /** SSE read timeout in seconds */
+  sse_read_timeout?: number;
 };
 
 export type ToggleMCPServerDto = {
@@ -1641,6 +1653,24 @@ export type MCPServerPingResponseDto = {
   status: MCPServerPingResponseDtoStatus;
   /** Latency in ms */
   latency?: number;
+};
+
+export type WorkspaceMemoryResponseDto = {
+  id: string;
+  workspaceId: string;
+  userId: string;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type GetManyWorkspaceMemoryResponseDtoDto = {
+  data: WorkspaceMemoryResponseDto[];
+  total: number;
+  page: number;
+  limit: number;
+  hasNextPage: boolean;
+  pageCount: number;
 };
 
 export type SkillResponseDto = {
@@ -2508,6 +2538,14 @@ export type AgentsControllerGetConversationsParams = {
 };
 
 export type AgentsControllerGetMessagesParams = {
+  search?: string;
+  page?: number;
+  limit?: number;
+  sortBy?: string;
+  sortOrder?: string;
+};
+
+export type AgentsControllerGetWorkspaceMemoryParams = {
   search?: string;
   page?: number;
   limit?: number;
@@ -19875,6 +19913,456 @@ export function useAgentsControllerPingMCPServer<
 
   return { ...query, queryKey: queryOptions.queryKey };
 }
+
+/**
+ * Get long-term memory records for the workspace (paginated, per user)
+ * @summary Get workspace memory
+ */
+export const agentsControllerGetWorkspaceMemory = (
+  params?: AgentsControllerGetWorkspaceMemoryParams,
+  options?: SecondParameter<typeof orvalClient>,
+  signal?: AbortSignal,
+) => {
+  return orvalClient<GetManyWorkspaceMemoryResponseDtoDto>(
+    { url: `/api/agents/workspace-memory`, method: 'GET', params, signal },
+    options,
+  );
+};
+
+export const getAgentsControllerGetWorkspaceMemoryInfiniteQueryKey = (
+  params?: AgentsControllerGetWorkspaceMemoryParams,
+) => {
+  return [
+    'infinite',
+    `/api/agents/workspace-memory`,
+    ...(params ? [params] : []),
+  ] as const;
+};
+
+export const getAgentsControllerGetWorkspaceMemoryQueryKey = (
+  params?: AgentsControllerGetWorkspaceMemoryParams,
+) => {
+  return [`/api/agents/workspace-memory`, ...(params ? [params] : [])] as const;
+};
+
+export const getAgentsControllerGetWorkspaceMemoryInfiniteQueryOptions = <
+  TData = InfiniteData<
+    Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+    AgentsControllerGetWorkspaceMemoryParams['page']
+  >,
+  TError = unknown,
+>(
+  params?: AgentsControllerGetWorkspaceMemoryParams,
+  options?: {
+    query?: Partial<
+      UseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+        TError,
+        TData,
+        QueryKey,
+        AgentsControllerGetWorkspaceMemoryParams['page']
+      >
+    >;
+    request?: SecondParameter<typeof orvalClient>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ??
+    getAgentsControllerGetWorkspaceMemoryInfiniteQueryKey(params);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+    QueryKey,
+    AgentsControllerGetWorkspaceMemoryParams['page']
+  > = ({ signal, pageParam }) =>
+    agentsControllerGetWorkspaceMemory(
+      { ...params, page: pageParam ?? params?.['page'] },
+      requestOptions,
+      signal,
+    );
+
+  return { queryKey, queryFn, ...queryOptions } as UseInfiniteQueryOptions<
+    Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+    TError,
+    TData,
+    QueryKey,
+    AgentsControllerGetWorkspaceMemoryParams['page']
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type AgentsControllerGetWorkspaceMemoryInfiniteQueryResult = NonNullable<
+  Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>
+>;
+export type AgentsControllerGetWorkspaceMemoryInfiniteQueryError = unknown;
+
+export function useAgentsControllerGetWorkspaceMemoryInfinite<
+  TData = InfiniteData<
+    Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+    AgentsControllerGetWorkspaceMemoryParams['page']
+  >,
+  TError = unknown,
+>(
+  params: undefined | AgentsControllerGetWorkspaceMemoryParams,
+  options: {
+    query: Partial<
+      UseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+        TError,
+        TData,
+        QueryKey,
+        AgentsControllerGetWorkspaceMemoryParams['page']
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+          TError,
+          Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+          QueryKey
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof orvalClient>;
+  },
+  queryClient?: QueryClient,
+): DefinedUseInfiniteQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useAgentsControllerGetWorkspaceMemoryInfinite<
+  TData = InfiniteData<
+    Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+    AgentsControllerGetWorkspaceMemoryParams['page']
+  >,
+  TError = unknown,
+>(
+  params?: AgentsControllerGetWorkspaceMemoryParams,
+  options?: {
+    query?: Partial<
+      UseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+        TError,
+        TData,
+        QueryKey,
+        AgentsControllerGetWorkspaceMemoryParams['page']
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+          TError,
+          Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+          QueryKey
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof orvalClient>;
+  },
+  queryClient?: QueryClient,
+): UseInfiniteQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useAgentsControllerGetWorkspaceMemoryInfinite<
+  TData = InfiniteData<
+    Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+    AgentsControllerGetWorkspaceMemoryParams['page']
+  >,
+  TError = unknown,
+>(
+  params?: AgentsControllerGetWorkspaceMemoryParams,
+  options?: {
+    query?: Partial<
+      UseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+        TError,
+        TData,
+        QueryKey,
+        AgentsControllerGetWorkspaceMemoryParams['page']
+      >
+    >;
+    request?: SecondParameter<typeof orvalClient>;
+  },
+  queryClient?: QueryClient,
+): UseInfiniteQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+/**
+ * @summary Get workspace memory
+ */
+
+export function useAgentsControllerGetWorkspaceMemoryInfinite<
+  TData = InfiniteData<
+    Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+    AgentsControllerGetWorkspaceMemoryParams['page']
+  >,
+  TError = unknown,
+>(
+  params?: AgentsControllerGetWorkspaceMemoryParams,
+  options?: {
+    query?: Partial<
+      UseInfiniteQueryOptions<
+        Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+        TError,
+        TData,
+        QueryKey,
+        AgentsControllerGetWorkspaceMemoryParams['page']
+      >
+    >;
+    request?: SecondParameter<typeof orvalClient>;
+  },
+  queryClient?: QueryClient,
+): UseInfiniteQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions =
+    getAgentsControllerGetWorkspaceMemoryInfiniteQueryOptions(params, options);
+
+  const query = useInfiniteQuery(
+    queryOptions,
+    queryClient,
+  ) as UseInfiniteQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
+
+export const getAgentsControllerGetWorkspaceMemoryQueryOptions = <
+  TData = Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+  TError = unknown,
+>(
+  params?: AgentsControllerGetWorkspaceMemoryParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof orvalClient>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ??
+    getAgentsControllerGetWorkspaceMemoryQueryKey(params);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>
+  > = ({ signal }) =>
+    agentsControllerGetWorkspaceMemory(params, requestOptions, signal);
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type AgentsControllerGetWorkspaceMemoryQueryResult = NonNullable<
+  Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>
+>;
+export type AgentsControllerGetWorkspaceMemoryQueryError = unknown;
+
+export function useAgentsControllerGetWorkspaceMemory<
+  TData = Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+  TError = unknown,
+>(
+  params: undefined | AgentsControllerGetWorkspaceMemoryParams,
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+          TError,
+          Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof orvalClient>;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useAgentsControllerGetWorkspaceMemory<
+  TData = Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+  TError = unknown,
+>(
+  params?: AgentsControllerGetWorkspaceMemoryParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+          TError,
+          Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof orvalClient>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useAgentsControllerGetWorkspaceMemory<
+  TData = Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+  TError = unknown,
+>(
+  params?: AgentsControllerGetWorkspaceMemoryParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof orvalClient>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+/**
+ * @summary Get workspace memory
+ */
+
+export function useAgentsControllerGetWorkspaceMemory<
+  TData = Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+  TError = unknown,
+>(
+  params?: AgentsControllerGetWorkspaceMemoryParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof agentsControllerGetWorkspaceMemory>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof orvalClient>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getAgentsControllerGetWorkspaceMemoryQueryOptions(
+    params,
+    options,
+  );
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
+
+/**
+ * Delete a long-term memory record by ID
+ * @summary Delete workspace memory
+ */
+export const agentsControllerDeleteWorkspaceMemory = (
+  id: string,
+  options?: SecondParameter<typeof orvalClient>,
+  signal?: AbortSignal,
+) => {
+  return orvalClient<DefaultMessageResponseDto>(
+    { url: `/api/agents/workspace-memory/${id}`, method: 'DELETE', signal },
+    options,
+  );
+};
+
+export const getAgentsControllerDeleteWorkspaceMemoryMutationOptions = <
+  TError = unknown,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof agentsControllerDeleteWorkspaceMemory>>,
+    TError,
+    { id: string },
+    TContext
+  >;
+  request?: SecondParameter<typeof orvalClient>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof agentsControllerDeleteWorkspaceMemory>>,
+  TError,
+  { id: string },
+  TContext
+> => {
+  const mutationKey = ['agentsControllerDeleteWorkspaceMemory'];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      'mutationKey' in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof agentsControllerDeleteWorkspaceMemory>>,
+    { id: string }
+  > = (props) => {
+    const { id } = props ?? {};
+
+    return agentsControllerDeleteWorkspaceMemory(id, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type AgentsControllerDeleteWorkspaceMemoryMutationResult = NonNullable<
+  Awaited<ReturnType<typeof agentsControllerDeleteWorkspaceMemory>>
+>;
+
+export type AgentsControllerDeleteWorkspaceMemoryMutationError = unknown;
+
+/**
+ * @summary Delete workspace memory
+ */
+export const useAgentsControllerDeleteWorkspaceMemory = <
+  TError = unknown,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof agentsControllerDeleteWorkspaceMemory>>,
+      TError,
+      { id: string },
+      TContext
+    >;
+    request?: SecondParameter<typeof orvalClient>;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof agentsControllerDeleteWorkspaceMemory>>,
+  TError,
+  { id: string },
+  TContext
+> => {
+  return useMutation(
+    getAgentsControllerDeleteWorkspaceMemoryMutationOptions(options),
+    queryClient,
+  );
+};
 
 /**
  * Get all available skills (builtin + user) for the workspace

--- a/core-api/src/database/migrations/1778100000001-AgentWorkspaceMemoryAddUserId.ts
+++ b/core-api/src/database/migrations/1778100000001-AgentWorkspaceMemoryAddUserId.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AgentWorkspaceMemoryAddUserId1778100000001 implements MigrationInterface {
+    name = 'AgentWorkspaceMemoryAddUserId1778100000001'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Drop the old unique index on workspaceId only
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_agent_workspace_memories_workspaceId"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "IDX_5e280da4a9fefee54d1857118d"`);
+
+        // Add userId column (nullable first to handle existing rows)
+        await queryRunner.query(`ALTER TABLE "agent_workspace_memories" ADD "userId" uuid`);
+
+        // Create composite unique index on [workspaceId, userId]
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_agent_workspace_memories_workspaceId_userId" ON "agent_workspace_memories" ("workspaceId", "userId")`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // Drop the composite unique index
+        await queryRunner.query(`DROP INDEX "IDX_agent_workspace_memories_workspaceId_userId"`);
+
+        // Remove userId column
+        await queryRunner.query(`ALTER TABLE "agent_workspace_memories" DROP COLUMN "userId"`);
+
+        // Restore old unique index on workspaceId
+        await queryRunner.query(`CREATE UNIQUE INDEX "IDX_5e280da4a9fefee54d1857118d" ON "agent_workspace_memories" ("workspaceId")`);
+    }
+}

--- a/core-api/src/modules/agents/agents.completions.ts
+++ b/core-api/src/modules/agents/agents.completions.ts
@@ -757,6 +757,7 @@ export class AgentsCompletionsService {
     conversation: AgentConversation,
     workspaceId: string,
     agentMode: AgentMode,
+    userId?: string,
   ): Promise<string[]> {
     // Fetch prompt for the current mode (e.g. ASK.md, AGENT.md)
     const modePrompt = this.getPrompt(`${agentMode.toUpperCase()}.md`);
@@ -770,7 +771,7 @@ export class AgentsCompletionsService {
     // Fetch STM and LTM concurrently
     const [stmContext, ltmContext] = await Promise.all([
       this.agentsMemories.stmFormatForPrompt(conversation.id),
-      this.agentsMemories.ltmFormatForPrompt(workspaceId),
+      userId ? this.agentsMemories.ltmFormatForPrompt(workspaceId, userId) : Promise.resolve(''),
     ]);
 
     const todoEntities = await this.todoRepository.find({
@@ -1333,6 +1334,7 @@ export class AgentsCompletionsService {
   private createContinuationStream(
     options: StreamTextOptions & {
       workspaceId: string;
+      userId?: string;
       skillsContext?: string;
     },
   ): ReadableStream<UIMessageChunk> {
@@ -1344,6 +1346,7 @@ export class AgentsCompletionsService {
       abortSignal,
       agentMode,
       workspaceId,
+      userId,
       skillsContext,
     } = options;
 
@@ -1433,7 +1436,7 @@ export class AgentsCompletionsService {
                   const currentTimeContext = `Current time: ${now.toISOString()} (${now.toLocaleString('en-US', { timeZoneName: 'short' })})`;
                   const [stmCtx, ltmCtx] = await Promise.all([
                     this.agentsMemories.stmFormatForPrompt(conversationId),
-                    this.agentsMemories.ltmFormatForPrompt(workspaceId),
+                    userId ? this.agentsMemories.ltmFormatForPrompt(workspaceId, userId) : Promise.resolve(''),
                   ]);
                   const postCompactTodos = await this.todoRepository.find({
                     where: { conversationId },
@@ -1589,7 +1592,7 @@ export class AgentsCompletionsService {
               const currentTimeContext = `Current time: ${now.toISOString()} (${now.toLocaleString('en-US', { timeZoneName: 'short' })})`;
               const [stmContext, ltmContext] = await Promise.all([
                 this.agentsMemories.stmFormatForPrompt(conversationId),
-                this.agentsMemories.ltmFormatForPrompt(workspaceId),
+                userId ? this.agentsMemories.ltmFormatForPrompt(workspaceId, userId) : Promise.resolve(''),
               ]);
               const updatedTodoEntities = await this.todoRepository.find({
                 where: { conversationId },
@@ -1752,6 +1755,7 @@ export class AgentsCompletionsService {
       conversation,
       workspaceId,
       agentMode,
+      userId,
     );
 
     // Step 10.5: Add skills context and loadSkill tool
@@ -1786,6 +1790,7 @@ export class AgentsCompletionsService {
       // Add memory tools
       ...(this.agentTool.getMemoryTools(
         workspaceId,
+        userId,
         conversation.id,
       ) as ToolSet),
     };
@@ -1807,6 +1812,7 @@ export class AgentsCompletionsService {
       abortSignal,
       agentMode,
       workspaceId,
+      userId,
       skillsContext,
     });
 

--- a/core-api/src/modules/agents/agents.controller.ts
+++ b/core-api/src/modules/agents/agents.controller.ts
@@ -56,6 +56,7 @@ import {
   ToggleSkillDto,
   UpdateSkillDto,
 } from './dto/skill.dto';
+import { WorkspaceMemoryResponseDto } from './dto/workspace-memory.dto';
 
 @ApiTags('Agents')
 @Controller('agents')
@@ -507,6 +508,45 @@ export class AgentsController {
     @WorkspaceId() workspaceId: string,
   ): Promise<MCPServerPingResponseDto> {
     return this.agentsService.pingMCPServer(workspaceId, name);
+  }
+
+  // ==========================================
+  // Workspace Memory Endpoints
+  // ==========================================
+
+  @Get('workspace-memory')
+  @Doc({
+    summary: 'Get workspace memory',
+    description:
+      'Get long-term memory records for the workspace (paginated, per user)',
+    request: { getWorkspaceId: true },
+    response: { serialization: GetManyResponseDto(WorkspaceMemoryResponseDto) },
+  })
+  getWorkspaceMemory(
+    @Query() query: GetManyBaseQueryParams,
+    @WorkspaceId() workspaceId: string,
+    @UserId() userId: string,
+  ): Promise<GetManyBaseResponseDto<WorkspaceMemoryResponseDto>> {
+    return this.agentsService.getWorkspaceMemory(workspaceId, userId, query);
+  }
+
+  @Delete('workspace-memory/:id')
+  @Doc({
+    summary: 'Delete workspace memory',
+    description: 'Delete a long-term memory record by ID',
+    request: {
+      getWorkspaceId: true,
+      params: [{ name: 'id', description: 'Memory record ID' }],
+    },
+    response: { serialization: DefaultMessageResponseDto },
+  })
+  async deleteWorkspaceMemory(
+    @Param('id') id: string,
+    @WorkspaceId() workspaceId: string,
+    @UserId() userId: string,
+  ): Promise<DefaultMessageResponseDto> {
+    await this.agentsService.deleteWorkspaceMemory(id, workspaceId, userId);
+    return { message: 'Memory deleted successfully' };
   }
 
   // ==========================================

--- a/core-api/src/modules/agents/agents.mcp.ts
+++ b/core-api/src/modules/agents/agents.mcp.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { AgentsService } from './agents.service';
 import { MCPServerResponseDto } from './dto/mcp-config.dto';
 
@@ -32,6 +32,29 @@ export class AgentsMcpService {
     return allTools;
   }
 
+  private createTransport(server: MCPServerResponseDto) {
+    if (!server.url) {
+      return null;
+    }
+
+    const url = new URL(server.url);
+    const headers = server.headers ?? {};
+
+    if (server.transport === 'streamable-http') {
+      return new StreamableHTTPClientTransport(url, {
+        requestInit: {
+          headers,
+        },
+      });
+    }
+
+    return new SSEClientTransport(url, {
+      requestInit: {
+        headers,
+      },
+    });
+  }
+
   private async fetchToolsFromServer(
     server: MCPServerResponseDto,
   ): Promise<Record<string, unknown>> {
@@ -45,19 +68,8 @@ export class AgentsMcpService {
       },
     );
 
-    let transport;
-    if (server.url) {
-      transport = new SSEClientTransport(new URL(server.url));
-    } else if (server.command) {
-      transport = new StdioClientTransport({
-        command: server.command,
-        args: server.args || [],
-        env: {
-          ...process.env,
-          ...(server.env || {}),
-        } as Record<string, string>,
-      });
-    } else {
+    const transport = this.createTransport(server);
+    if (!transport) {
       return {};
     }
 
@@ -110,20 +122,9 @@ export class AgentsMcpService {
       },
     );
 
-    let transport;
-    if (server.url) {
-      transport = new SSEClientTransport(new URL(server.url));
-    } else if (server.command) {
-      transport = new StdioClientTransport({
-        command: server.command,
-        args: server.args || [],
-        env: {
-          ...process.env,
-          ...(server.env || {}),
-        } as Record<string, string>,
-      });
-    } else {
-      throw new Error(`Invalid MCP server configuration for ${server.name}`);
+    const transport = this.createTransport(server);
+    if (!transport) {
+      throw new Error(`Invalid MCP server configuration for ${server.name}: missing URL`);
     }
 
     try {

--- a/core-api/src/modules/agents/agents.memories.ts
+++ b/core-api/src/modules/agents/agents.memories.ts
@@ -1,5 +1,5 @@
 import { RedisService } from '@/services/redis/redis.service';
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { AgentWorkspaceMemory } from './entities/agent-workspace-memory.entity';
@@ -104,27 +104,57 @@ export class AgentsMemoriesService {
   }
 
   /**
-   * Returns the LTM record for the workspace, creates an empty one if not exists.
+   * Returns the LTM record for the user in a workspace, creates an empty one if not exists.
    */
-  async ltmGet(workspaceId: string): Promise<AgentWorkspaceMemory> {
-    let record = await this.ltmRepository.findOne({ where: { workspaceId } });
+  async ltmGet(workspaceId: string, userId: string): Promise<AgentWorkspaceMemory> {
+    let record = await this.ltmRepository.findOne({ where: { workspaceId, userId } });
     if (!record) {
-      record = this.ltmRepository.create({ workspaceId, content: '' });
+      record = this.ltmRepository.create({ workspaceId, userId, content: '' });
       record = await this.ltmRepository.save(record);
     }
     return record;
   }
 
+  async ltmGetAll(workspaceId: string, userId: string): Promise<AgentWorkspaceMemory[]> {
+    return this.ltmRepository.find({
+      where: { workspaceId, userId },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async ltmGetAllPaginated(
+    workspaceId: string,
+    userId: string,
+    options?: { page?: number; limit?: number; sortBy?: string; sortOrder?: 'ASC' | 'DESC' },
+  ): Promise<{ data: AgentWorkspaceMemory[]; total: number }> {
+    const page = options?.page || 1;
+    const limit = options?.limit || 10;
+    const sortBy = options?.sortBy || 'createdAt';
+    const sortOrder = options?.sortOrder || 'DESC';
+
+    const qb = this.ltmRepository
+      .createQueryBuilder('memory')
+      .where('memory.workspaceId = :workspaceId', { workspaceId })
+      .andWhere('memory.userId = :userId', { userId })
+      .orderBy(`memory.${sortBy}`, sortOrder)
+      .skip((page - 1) * limit)
+      .take(limit);
+
+    const [data, total] = await qb.getManyAndCount();
+    return { data, total };
+  }
+
   /**
-   * Overwrites the LTM content for the workspace.
+   * Overwrites the LTM content for the user in a workspace.
    */
   async ltmSet(
     workspaceId: string,
+    userId: string,
     content: string,
   ): Promise<AgentWorkspaceMemory> {
-    let record = await this.ltmRepository.findOne({ where: { workspaceId } });
+    let record = await this.ltmRepository.findOne({ where: { workspaceId, userId } });
     if (!record) {
-      record = this.ltmRepository.create({ workspaceId, content });
+      record = this.ltmRepository.create({ workspaceId, userId, content });
     } else {
       record.content = content;
     }
@@ -132,18 +162,36 @@ export class AgentsMemoriesService {
   }
 
   /**
-   * Clears the LTM content for the workspace.
+   * Clears the LTM content for the user in a workspace.
    */
-  async ltmClear(workspaceId: string): Promise<void> {
-    await this.ltmRepository.update({ workspaceId }, { content: '' });
+  async ltmClear(workspaceId: string, userId: string): Promise<void> {
+    await this.ltmRepository.update({ workspaceId, userId }, { content: '' });
+  }
+
+  /**
+   * Deletes the LTM record for the user in a workspace.
+   */
+  async ltmDelete(workspaceId: string, userId: string): Promise<void> {
+    await this.ltmRepository.delete({ workspaceId, userId });
+  }
+
+  /**
+   * Deletes a specific LTM record by ID if it belongs to the user in the workspace.
+   */
+  async ltmDeleteById(id: string, workspaceId: string, userId: string): Promise<void> {
+    const record = await this.ltmRepository.findOne({ where: { id, workspaceId, userId } });
+    if (!record) {
+      throw new NotFoundException('Memory record not found');
+    }
+    await this.ltmRepository.remove(record);
   }
 
   /**
    * Returns LTM as a prompt context block.
    * Returns empty string if content is empty.
    */
-  async ltmFormatForPrompt(workspaceId: string): Promise<string> {
-    const record = await this.ltmRepository.findOne({ where: { workspaceId } });
+  async ltmFormatForPrompt(workspaceId: string, userId: string): Promise<string> {
+    const record = await this.ltmRepository.findOne({ where: { workspaceId, userId } });
     if (!record?.content?.trim()) return '';
     return `[Long-Term Memory]\n${record.content}`;
   }

--- a/core-api/src/modules/agents/agents.service.ts
+++ b/core-api/src/modules/agents/agents.service.ts
@@ -40,6 +40,7 @@ import {
   MCPServerResponseDto,
 } from './dto/mcp-config.dto';
 import { MessageResponseDto, ToolCallResponseDto } from './dto/message.dto';
+import { WorkspaceMemoryResponseDto } from './dto/workspace-memory.dto';
 import { AgentConversation } from './entities/agent-conversation.entity';
 import { AgentConversationTodo } from './entities/agent-conversation-todo.entity';
 import { AgentLLMConfig } from './entities/agent-llm-config.entity';
@@ -676,7 +677,9 @@ export class AgentsService {
     const existing = config.configJson.mcpServers[name] ?? {};
     config.configJson.mcpServers[name] = {
       disabled: false,
+      transport: 'sse',
       timeout: 60,
+      sse_read_timeout: 300,
       allowed_tools: null,
       ...existing,
       ...dto,
@@ -761,5 +764,43 @@ export class AgentsService {
     } catch {
       return { status: 'offline' };
     }
+  }
+
+  async getWorkspaceMemory(
+    workspaceId: string,
+    userId: string,
+    query?: GetManyBaseQueryParams,
+  ): Promise<GetManyBaseResponseDto<WorkspaceMemoryResponseDto>> {
+    const page = query?.page || 1;
+    const limit = query?.limit || 10;
+    const sortBy = query?.sortBy || 'createdAt';
+    const sortOrder = (query?.sortOrder || 'DESC') as 'ASC' | 'DESC';
+
+    const { data, total } = await this.agentsMemories.ltmGetAllPaginated(
+      workspaceId,
+      userId,
+      { page, limit, sortBy, sortOrder },
+    );
+
+    return getManyResponse({
+      query: { ...query, page, limit } as GetManyBaseQueryParams,
+      data: data.map((r) => ({
+        id: r.id,
+        workspaceId: r.workspaceId,
+        userId: r.userId,
+        content: r.content,
+        createdAt: r.createdAt,
+        updatedAt: r.updatedAt,
+      })),
+      total,
+    });
+  }
+
+  async deleteWorkspaceMemory(
+    id: string,
+    workspaceId: string,
+    userId: string,
+  ): Promise<void> {
+    await this.agentsMemories.ltmDeleteById(id, workspaceId, userId);
   }
 }

--- a/core-api/src/modules/agents/agents.tools.ts
+++ b/core-api/src/modules/agents/agents.tools.ts
@@ -724,6 +724,7 @@ export class AgentTool {
 
   getMemoryTools(
     workspaceId: string,
+    userId: string,
     conversationId: string,
   ): Record<string, ToolType> {
     const memoriesService = this.agentsMemories;
@@ -822,7 +823,7 @@ export class AgentTool {
       }),
       execute: async (params: { content: string }) => {
         try {
-          await memoriesService.ltmSet(workspaceId, params.content);
+          await memoriesService.ltmSet(workspaceId, userId, params.content);
           return {
             success: true,
             message: 'Saved to long-term memory.',
@@ -845,11 +846,11 @@ export class AgentTool {
       }),
       execute: async (params: { content: string }) => {
         try {
-          const existing = await memoriesService.ltmGet(workspaceId);
+          const existing = await memoriesService.ltmGet(workspaceId, userId);
           const newContent = existing.content
             ? `${existing.content}\n\n${params.content}`
             : params.content;
-          await memoriesService.ltmSet(workspaceId, newContent);
+          await memoriesService.ltmSet(workspaceId, userId, newContent);
           return {
             success: true,
             message: 'Appended to long-term memory.',
@@ -866,7 +867,7 @@ export class AgentTool {
       parameters: z.object({}),
       execute: async () => {
         try {
-          const record = await memoriesService.ltmGet(workspaceId);
+          const record = await memoriesService.ltmGet(workspaceId, userId);
           return { content: record.content || '(empty)' };
         } catch (error) {
           const message = error instanceof Error ? error.message : String(error);

--- a/core-api/src/modules/agents/dto/mcp-config.dto.ts
+++ b/core-api/src/modules/agents/dto/mcp-config.dto.ts
@@ -3,6 +3,7 @@ import { Type } from 'class-transformer';
 import {
   IsArray,
   IsBoolean,
+  IsIn,
   IsNumber,
   IsObject,
   IsOptional,
@@ -16,26 +17,15 @@ export class MCPServerConfigDto {
   @IsString()
   url?: string;
 
+  @ApiPropertyOptional({ enum: ['sse', 'streamable-http'], example: 'sse', default: 'sse' })
+  @IsOptional()
+  @IsIn(['sse', 'streamable-http'])
+  transport?: 'sse' | 'streamable-http';
+
   @ApiPropertyOptional({ example: { 'api-key': 'sk-...' } })
   @IsOptional()
   @IsObject()
   headers?: Record<string, string>;
-
-  @ApiPropertyOptional({ example: 'npx' })
-  @IsOptional()
-  @IsString()
-  command?: string;
-
-  @ApiPropertyOptional({ example: ['-y', '@modelcontextprotocol/server-filesystem'] })
-  @IsOptional()
-  @IsArray()
-  @IsString({ each: true })
-  args?: string[];
-
-  @ApiPropertyOptional({ example: { PATH: '/usr/bin' } })
-  @IsOptional()
-  @IsObject()
-  env?: Record<string, string>;
 
   @ApiPropertyOptional({ example: false, default: false })
   @IsOptional()
@@ -54,6 +44,13 @@ export class MCPServerConfigDto {
   @Min(1)
   @Type(() => Number)
   timeout?: number;
+
+  @ApiPropertyOptional({ example: 300, default: 300, description: 'SSE read timeout in seconds' })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  @Type(() => Number)
+  sse_read_timeout?: number;
 }
 
 export class MCPServerResponseDto extends MCPServerConfigDto {

--- a/core-api/src/modules/agents/dto/workspace-memory.dto.ts
+++ b/core-api/src/modules/agents/dto/workspace-memory.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class WorkspaceMemoryResponseDto {
+  @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440000' })
+  id: string;
+
+  @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440000' })
+  workspaceId: string;
+
+  @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440000' })
+  userId: string;
+
+  @ApiProperty({
+    example: '## Key Facts\n- User prefers concise answers\n- Target scope: internal network',
+  })
+  content: string;
+
+  @ApiProperty({ example: '2025-01-01T00:00:00.000Z' })
+  createdAt: Date;
+
+  @ApiProperty({ example: '2025-01-01T00:00:00.000Z' })
+  updatedAt: Date;
+}

--- a/core-api/src/modules/agents/entities/agent-mcp-config.entity.ts
+++ b/core-api/src/modules/agents/entities/agent-mcp-config.entity.ts
@@ -4,15 +4,16 @@ import { IsUUID } from 'class-validator';
 import { Workspace } from '@/modules/workspaces/entities/workspace.entity';
 import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
 
+export type MCPServerTransport = 'sse' | 'streamable-http';
+
 export interface MCPServerConfig {
   url?: string;
+  transport?: MCPServerTransport;
   headers?: Record<string, string>;
-  command?: string;
-  args?: string[];
-  env?: Record<string, string>;
   disabled?: boolean;
   allowed_tools?: string[] | null;
   timeout?: number;
+  sse_read_timeout?: number;
 }
 
 export interface MCPConfigJson {

--- a/core-api/src/modules/agents/entities/agent-workspace-memory.entity.ts
+++ b/core-api/src/modules/agents/entities/agent-workspace-memory.entity.ts
@@ -1,15 +1,25 @@
 import { BaseEntity } from '@/common/entities/base.entity';
+import { User } from '@/modules/auth/entities/user.entity';
 import { ApiProperty } from '@nestjs/swagger';
 import { IsString, IsUUID } from 'class-validator';
-import { Column, Entity, Index } from 'typeorm';
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm';
 
 @Entity('agent_workspace_memories')
-@Index(['workspaceId'], { unique: true })
+@Index(['workspaceId', 'userId'], { unique: true })
 export class AgentWorkspaceMemory extends BaseEntity {
   @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440000' })
   @IsUUID()
   @Column({ type: 'uuid' })
   workspaceId: string;
+
+  @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440000' })
+  @IsUUID()
+  @Column({ type: 'uuid', nullable: true })
+  userId: string;
+
+  @ManyToOne(() => User, { eager: false })
+  @JoinColumn({ name: 'userId' })
+  user: User;
 
   @ApiProperty({
     description: 'Long-term memory content in Markdown format',

--- a/core-api/src/modules/agents/skills/command-execution/SKILL.md
+++ b/core-api/src/modules/agents/skills/command-execution/SKILL.md
@@ -1,58 +1,120 @@
 ---
 name: command-execution
-description: Execute security scanning commands on remote worker agents and perform external web research for CVE lookup and threat intelligence.
+description: Execute security scanning commands on remote worker agents. Use when you need to run CLI tools like nmap, subfinder, httpx, nuclei, or any shell command on worker nodes.
 ---
 
-# Command Execution & Web Research
+# Command Execution
 
-Use this skill when you need to run CLI security tools on remote workers or perform external web research for threat intelligence.
+Use this skill when you need to run CLI security tools on remote worker nodes via `execute_remote_command`.
 
-## Executing Commands on Workers
+## Workflow
 
-Use `execute_remote_command` to send CLI commands to worker agents for scanning and analysis.
+### 1. Check Worker Availability
 
-### What to Run
+Before executing commands, verify workers are online:
 
-- Subdomain discovery (`subfinder`, `amass`, etc.)
-- HTTP probing (`httpx`, etc.)
-- Port scanning (`naabu`, `nmap`, etc.)
-- Vulnerability scanning (`nuclei`, etc.)
-- Screenshot capture (`gowitness`, `aquatone`, etc.)
-- DNS enumeration (`dnsx`, `dig`, etc.)
-- Any CLI security tool available in the worker environment
+```
+Use list_active_workers to confirm at least one worker is available.
+```
 
-### Command Format
+If no workers are available, inform the user and suggest they wait or check worker status.
 
-Pass commands as you would in a terminal:
+### 2. Understand the Tool
 
+`execute_remote_command` runs arbitrary shell commands on remote workers.
+
+**Parameters:**
+- `command` (string, required): The shell command to execute
+
+**Output fields:**
+- `stdout`: Standard output
+- `stderr`: Standard error
+- `exitCode`: Process exit code (0 = success)
+- `error`: Error message if execution failed
+- `timedOut`: Whether the command exceeded timeout
+
+**Constraints:**
+- No PTY (non-interactive)
+- Strict timeout (60 seconds default)
+- OS-level permissions apply
+- Commands run in the worker's environment (tools must be installed)
+
+### 3. Choose the Right Tool
+
+Not everything needs remote execution. Use the right tool for the job:
+
+| Task | Tool |
+|---|---|
+| Run CLI scanners (nmap, nuclei, subfinder, etc.) | `execute_remote_command` |
+| List workspace assets, vulns, ports, technologies | Use `enumerate_assets`, `discover_vulnerabilities`, `list_network_ports`, `fingerprint_technologies` |
+| Get details on a specific asset or vulnerability | Use `inspect_asset`, `investigate_vulnerability` |
+| Fetch a web page | Use `retrieve_web_page` |
+
+Only use `execute_remote_command` when you need to run a CLI tool that is not available through the built-in OASM tools.
+
+### 4. Build the Command
+
+Use standard CLI syntax. Examples by category:
+
+**Subdomain Discovery:**
 ```
 subfinder -d example.com -silent
-httpx -l subdomains.txt -status-code -title -tech-detect
-naabu -host example.com -top-ports 1000
-nuclei -u https://example.com -severity critical,high
+amass enum -passive -d example.com
 ```
 
-## External Research
+**HTTP Probing:**
+```
+httpx -l subdomains.txt -status-code -title -tech-detect
+httpx -u https://example.com -follow-redirects -status-code
+```
 
-### CVE Lookup
+**Port Scanning:**
+```
+naabu -host example.com -top-ports 1000
+nmap -sV -sC -oX output.xml example.com
+nmap -p 80,443,8080,8443 example.com
+```
 
-1. Fetch from: `https://raw.githubusercontent.com/trickest/cve/refs/heads/main/{YEAR}/CVE-{YEAR}-{NUMBER}.md`
-2. Extract: description, affected versions, severity, remediation
-3. If not found, suggest NVD as alternative
+**Vulnerability Scanning:**
+```
+nuclei -u https://example.com -severity critical,high
+nuclei -l urls.txt -severity critical,high,medium
+```
 
-### Web Search
+**DNS Enumeration:**
+```
+dig example.com ANY
+dnsx -d example.com -silent
+```
 
-- Use `retrieve_web_page` for known URLs
-- Use specific, targeted queries with year/version numbers
-- For emerging threats, zero-days, or security concepts
+**Screenshot Capture:**
+```
+gowitness file -f urls.txt -P ./screenshots
+```
 
-### Deep Content Analysis
+**OSINT / Recon:**
+```
+theHarvester -d example.com -b all
+```
 
-- After fetching a URL, analyze thoroughly
-- Fetch linked references for comprehensive answers (max 3-5 recursive fetches)
-- Synthesize multiple sources into actionable insights
+### 5. Execute and Analyze
 
-## Tool Usage Rules
+1. Run the command via `execute_remote_command`
+2. Check `exitCode` — non-zero may indicate partial results (e.g., nmap found nothing)
+3. Parse `stdout` for findings
+4. Check `stderr` for warnings or errors
+5. If the command times out, suggest breaking it into smaller scans or increasing scope
 
-- Never expose internal tool names. Say "I found X assets" not "get_assets returned".
-- Focus on results and insights, not the mechanism.
+### 6. Save Results
+
+After scanning, save important findings to memory:
+
+- Use `stm_write` to store scan results (e.g., key: `"subdomain_results"`, value: the output)
+- Use `ltm_append` to persist critical findings across conversations
+
+## Safety Rules
+
+- **Scope check**: Only run scans against targets within the workspace scope. Use `retrieve_targets` to verify scope before scanning.
+- **Avoid destructive flags**: Do not use `--rm`, `rm -rf`, or similar commands that could damage the worker.
+- **Prefer read-only scans**: Use `-sV` (version detection) over `-O` (OS detection) when possible — less intrusive.
+- **Rate limiting**: Add delays between bulk operations (e.g., `--rate-limit` flags) to avoid overwhelming targets.

--- a/core-api/src/modules/agents/skills/vulnerability-analysis/SKILL.md
+++ b/core-api/src/modules/agents/skills/vulnerability-analysis/SKILL.md
@@ -7,7 +7,7 @@ description: Perform deep analysis of CVEs and security vulnerabilities includin
 
 Use this skill when the user asks for detailed vulnerability analysis beyond basic CVE lookup.
 
-## When to use this skill
+## When to Use
 
 - User asks "how serious is this vulnerability?"
 - User asks about exploit availability or PoC code
@@ -15,48 +15,96 @@ Use this skill when the user asks for detailed vulnerability analysis beyond bas
 - User asks about mitigation or remediation steps
 - User wants to prioritize which vulnerabilities to fix first
 
-## Analysis Framework
+## Workflow
 
-For each vulnerability, analyze these dimensions:
+### 1. Gather Vulnerability Data
 
-### 1. Severity Assessment
+Start with built-in OASM tools to get workspace context:
+
+| Tool | Purpose |
+|---|---|
+| `discover_vulnerabilities` | List vulns matching a query (e.g., "CVE-2024", "XSS") |
+| `investigate_vulnerability` | Get full details on a specific vulnerability by ID |
+| `enumerate_assets` | Find assets that may run affected software |
+| `fingerprint_technologies` | Identify technologies in use to check exposure |
+| `list_network_ports` | Check if vulnerable services are exposed |
+| `enumerate_open_issues` | See if the vulnerability is already tracked |
+
+### 2. Enrich with External Sources
+
+For deeper analysis, use `retrieve_web_page` to fetch from these sources:
+
+**CVE Details:**
+- Trickest CVE: `https://raw.githubusercontent.com/trickest/cve/refs/heads/main/{YEAR}/CVE-{YEAR}-{NUMBER}.md`
+- NVD API: `https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-{YEAR}-{NUMBER}`
+
+**Exploit Intelligence:**
+- GitHub PoC search: `https://github.com/nomi-sec/PoC-in-GitHub`
+- Exploit-DB: `https://www.exploit-db.com/search`
+- Metasploit modules: `https://www.rapid7.com/db/modules/`
+
+**Vendor Advisories:**
+- Microsoft MSRC: `https://msrc.microsoft.com/update-guide/vulnerability/CVE-{YEAR}-{NUMBER}`
+- Apache security: `https://lists.apache.org/thread/`
+
+### 3. Analyze the Vulnerability
+
+For each vulnerability, evaluate these dimensions:
+
+#### Severity Assessment
 - CVSS v3.1 base score and vector string
 - EPSS (Exploit Prediction Scoring System) if available
 - CISA KEV (Known Exploited Vulnerabilities) catalog status
-- Contextual severity based on asset exposure (is the affected component internet-facing?)
+- Contextual severity: is the affected component internet-facing?
 
-### 2. Exploit Maturity
-- Check known PoC repos: `https://github.com/nomi-sec/PoC-in-GitHub` search
-- Check Metasploit modules: `https://www.rapid7.com/db/modules/` search
-- Check exploit-db: `https://www.exploit-db.com/search`
-- Categorize as: None / PoC / Functional / Weaponized
+#### Exploit Maturity
+Categorize the exploit status:
+- **None**: No known exploits
+- **PoC**: Proof-of-concept code exists (GitHub, write-ups)
+- **Functional**: Exploit works reliably but not mass-deployed
+- **Weaponized**: Used in real attacks, available in exploit frameworks
 
-### 3. Affected Scope
-- List affected products and versions
-- Check if OASM assets match (use `discover_vulnerabilities` or `investigate_vulnerability`)
-- Check exposure: internet-facing vs internal-only
+#### Affected Scope
+- List affected products and versions from the CVE
+- Cross-reference with workspace assets using `enumerate_assets` and `fingerprint_technologies`
+- Determine exposure: internet-facing vs internal-only
 
-### 4. Remediation Guidance
+#### Remediation Guidance
 - Patch availability and version
 - Workarounds if no patch exists (WAF rules, network segmentation, disable feature)
-- Estimated priority: Immediate (exploited in wild) / High (PoC available) / Medium / Low
+- Priority level:
+  - **Immediate**: Exploited in the wild (check CISA KEV)
+  - **High**: Functional exploit or PoC available
+  - **Medium**: Vulnerable but no known exploit
+  - **Low**: Informational or low-impact
 
-## Output Format
+### 4. Present Findings
 
-When presenting vulnerability analysis, structure as:
+Structure your analysis as:
 
-**Summary**: One-line overview
+```
+**Summary**: One-line overview of the vulnerability
+
 **Severity**: CVSS score + vector + EPSS (if available)
-**Exploit Status**: None / PoC / Active
-**Affected Assets**: X assets in your workspace match (list top 5)
-**Impact**: What an attacker can achieve
+
+**Exploit Status**: None / PoC / Functional / Weaponized
+
+**Affected Assets**: X assets in your workspace match
+- asset1.example.com (nginx 1.18)
+- asset2.example.com (Apache 2.4.49)
+
+**Impact**: What an attacker can achieve (e.g., RCE, data leak, DoS)
+
 **Remediation**: Specific steps with version numbers
+- Upgrade to X.Y.Z or later
+- Temporary: apply WAF rule / disable feature
+
 **Priority**: Immediate / High / Medium / Low
+```
 
-## Integration with OASM Tools
+### 5. Track the Issue
 
-- Use `discover_vulnerabilities` to find related vulnerabilities in the workspace
-- Use `investigate_vulnerability` to get detailed info on a specific vuln
-- Use `examine_target_assets` to check which targets are affected
-- Use `enumerate_open_issues` to see if there are already tracking issues
-- Cross-reference with `list_network_ports` and `fingerprint_technologies` for context
+After analysis:
+- If no existing issue, suggest creating one via the Issues system
+- Store key findings in `stm_write` for reference during the conversation
+- Use `ltm_append` to persist critical vulnerability intelligence for the workspace

--- a/core-api/src/modules/agents/skills/web-research/SKILL.md
+++ b/core-api/src/modules/agents/skills/web-research/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: web-research
-description: Perform advanced web research using search engines, CVE databases, and vendor advisories. Use when the user asks about CVEs, security news, vulnerabilities, patch releases, or any external security information.
+description: Perform web research using CVE databases, security advisories, and threat intelligence sources. Use when the user asks about CVEs, security news, vulnerabilities, patch releases, or any external security information not available in the workspace.
 ---
 
 # Web Research
 
 Use this skill when you need to find external security information that is not already in the OASM platform.
 
-## When to use this skill
+## When to Use
 
 - User asks about a specific CVE (e.g., "what is CVE-2024-1234?")
 - User asks about recent vulnerabilities or exploits
@@ -15,31 +15,65 @@ Use this skill when you need to find external security information that is not a
 - User asks about industry-specific threats or news
 - User needs context about a technology or software vulnerability
 
-## CVE Lookup
+## Core Tool: `retrieve_web_page`
 
-1. Fetch from: `https://raw.githubusercontent.com/trickest/cve/refs/heads/main/{YEAR}/CVE-{YEAR}-{NUMBER}.md`
-2. If not found, try NVD: `https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-{YEAR}-{NUMBER}`
-3. Extract: description, affected versions, severity (CVSS), and remediation
-4. Correlate with OASM assets — check if any assets run the affected software
-5. If you found matching assets, recommend scanning priority
+Use `retrieve_web_page` to fetch content from any public URL. It returns `statusCode` and `body`.
 
-## Web Search
+```
+retrieve_web_page({ url: "https://example.com/path" })
+```
 
-1. Use Brave Search: `https://search.brave.com/search?q={QUERY}&source=web`
-2. Use DuckDuckGo as fallback: `https://lite.duckduckgo.com/lite/?q={QUERY}`
-3. Use specific, targeted queries with year/version numbers
-4. For emerging threats, zero-days, or security concepts — search broad and narrow down
+Always use `retrieve_web_page` instead of trying to construct fetch requests manually. It handles User-Agent headers and error handling automatically.
 
-## Vendor Advisory Lookup
+## Workflow
 
-- For Microsoft: `https://msrc.microsoft.com/update-guide/vulnerability/CVE-{YEAR}-{NUMBER}`
-- For Apache: `https://lists.apache.org/thread/` search
-- For Linux distributions: check their security tracker pages
-- For npm/PyPI: check their security advisories database
+### 1. Identify What You Need
 
-## Deep Content Analysis
+Before fetching, know what information you're looking for:
+- CVE details → fetch from Trickest/NVD
+- Exploit PoC → fetch from GitHub/Exploit-DB
+- Vendor patches → fetch from vendor advisory pages
+- Threat news → fetch from security news sites
 
-- After fetching a URL, analyze thoroughly
-- Fetch linked references for comprehensive answers (max 3-5 recursive fetches)
-- Synthesize multiple sources into actionable insights
-- Always map findings back to OASM entities (assets, vulnerabilities, targets)
+### 2. Build the URL
+
+Pick the right source for the query:
+
+| Query Type | Source | URL Pattern |
+|---|---|---|
+| CVE details | Trickest CVE | `https://raw.githubusercontent.com/trickest/cve/refs/heads/main/{YEAR}/CVE-{YEAR}-{NUMBER}.md` |
+| CVE details (alt) | NVD API | `https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-{YEAR}-{NUMBER}` |
+| Microsoft CVE | MSRC | `https://msrc.microsoft.com/update-guide/vulnerability/CVE-{YEAR}-{NUMBER}` |
+| Exploit code | GitHub | `https://github.com/search?q={QUERY}+exploit&type=repositories` |
+| Exploit modules | Exploit-DB | `https://www.exploit-db.com/search?q={QUERY}` |
+| Metasploit modules | Rapid7 | `https://www.rapid7.com/db/modules/?q={QUERY}` |
+| Apache advisories | Apache Mailing Lists | `https://lists.apache.org/` |
+| Package vulnerabilities | npm | `https://www.npmjs.com/advisories` |
+| Package vulnerabilities | PyPI | `https://pypi.org/security/` |
+
+### 3. Fetch and Analyze
+
+1. Call `retrieve_web_page` with the constructed URL
+2. Parse the `body` content — extract relevant sections
+3. If the page has links to related content, fetch up to 3-5 linked pages for comprehensive analysis
+4. Synthesize findings from multiple sources
+
+### 4. Correlate with Workspace
+
+After gathering external intel, map findings back to the workspace:
+
+- Use `enumerate_assets` or `fingerprint_technologies` to check if affected software is in use
+- Use `discover_vulnerabilities` to see if the CVE is already tracked
+- Use `enumerate_open_issues` to check if someone is already investigating
+
+### 5. Save Important Findings
+
+- Use `stm_write` to store research results for the current conversation
+- Use `ltm_append` to persist critical threat intelligence
+
+## Query Tips
+
+- Include version numbers: "Apache 2.4.49 path traversal" not just "Apache vulnerability"
+- Include year for CVEs: "CVE-2024-1234" narrows results
+- Use specific terms: "Log4Shell RCE" not "Log4j issue"
+- For zero-days, search for the vendor advisory page directly


### PR DESCRIPTION
- Add workspace memory entity with user_id scoping and migration
- Add memory manager UI component for managing agent memories
- Update MCP config DTOs and entity with new fields
- Improve skills manager UI with better interaction patterns
- Add memory endpoints to agents controller
- Update agent completions and tools for memory integration
- Update command-execution, vulnerability-analysis, and web-research skills
- Regenerate console API client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Memory tab in Agent Settings for viewing and managing workspace memory
  * Memory records are now scoped per user and can be listed and deleted (with confirmation)
  * Skills list rows can be expanded to show full content
  * MCP server options updated to support SSE and Streamable HTTP transports (with SSE timeout)

* **Documentation**
  * Revised skill guides: Command Execution, Vulnerability Analysis, and Web Research (clearer workflows and constraints)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->