### PR TITLE
feat(reports): implement secure time-limited file downloads

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,16 +1,5 @@
-# CodeGraph data files
-# These are local to each machine and should not be committed
-
-# Database
-*.db
-*.db-wal
-*.db-shm
-
-# Cache
-cache/
-
-# Logs
-*.log
-
-# Hook markers
-.dirty
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/console/src/pages/reports/reports.tsx
+++ b/console/src/pages/reports/reports.tsx
@@ -171,7 +171,7 @@ export default function Reports() {
   };
 
   const handleDownload = (report: ReportResponseDto) => {
-    window.open(`/api/storage/${report.path}`, '_blank');
+    window.open(report.downloadUrl, '_blank');
   };
 
   const handleDelete = (report: ReportResponseDto) => {

--- a/console/src/services/apis/gen/queries.ts
+++ b/console/src/services/apis/gen/queries.ts
@@ -2171,6 +2171,8 @@ export type ReportResponseDto = {
   fileName: string;
   type: ReportResponseDtoType;
   createdAt: string;
+  /** Presigned download URL (expires in 15 minutes) */
+  downloadUrl: string;
 };
 
 export type GetManyReportResponseDtoDto = {
@@ -2825,6 +2827,13 @@ export type StorageControllerUploadFile200 = {
   path?: string;
   bucket?: string;
   fullPath?: string;
+};
+
+export type StorageControllerDownloadFileParams = {
+  /**
+   * Time-limited download token
+   */
+  token: string;
 };
 
 export type StorageControllerForwardImageParams = {
@@ -31499,6 +31508,208 @@ export const useStorageControllerUploadFile = <
     queryClient,
   );
 };
+
+/**
+ * @summary Download a file with time-limited token
+ */
+export const storageControllerDownloadFile = (
+  bucket: string,
+  path: string,
+  params: StorageControllerDownloadFileParams,
+  options?: SecondParameter<typeof orvalClient>,
+  signal?: AbortSignal,
+) => {
+  return orvalClient<Blob>(
+    {
+      url: `/api/storage/${bucket}/${path}/download`,
+      method: 'GET',
+      params,
+      responseType: 'blob',
+      signal,
+    },
+    options,
+  );
+};
+
+export const getStorageControllerDownloadFileQueryKey = (
+  bucket: string,
+  path: string,
+  params?: StorageControllerDownloadFileParams,
+) => {
+  return [
+    `/api/storage/${bucket}/${path}/download`,
+    ...(params ? [params] : []),
+  ] as const;
+};
+
+export const getStorageControllerDownloadFileQueryOptions = <
+  TData = Awaited<ReturnType<typeof storageControllerDownloadFile>>,
+  TError = void,
+>(
+  bucket: string,
+  path: string,
+  params: StorageControllerDownloadFileParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof storageControllerDownloadFile>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof orvalClient>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ??
+    getStorageControllerDownloadFileQueryKey(bucket, path, params);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof storageControllerDownloadFile>>
+  > = ({ signal }) =>
+    storageControllerDownloadFile(bucket, path, params, requestOptions, signal);
+
+  return {
+    queryKey,
+    queryFn,
+    enabled:
+      bucket !== null &&
+      bucket !== undefined &&
+      path !== null &&
+      path !== undefined,
+    ...queryOptions,
+  } as UseQueryOptions<
+    Awaited<ReturnType<typeof storageControllerDownloadFile>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type StorageControllerDownloadFileQueryResult = NonNullable<
+  Awaited<ReturnType<typeof storageControllerDownloadFile>>
+>;
+export type StorageControllerDownloadFileQueryError = void;
+
+export function useStorageControllerDownloadFile<
+  TData = Awaited<ReturnType<typeof storageControllerDownloadFile>>,
+  TError = void,
+>(
+  bucket: string,
+  path: string,
+  params: StorageControllerDownloadFileParams,
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof storageControllerDownloadFile>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof storageControllerDownloadFile>>,
+          TError,
+          Awaited<ReturnType<typeof storageControllerDownloadFile>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof orvalClient>;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useStorageControllerDownloadFile<
+  TData = Awaited<ReturnType<typeof storageControllerDownloadFile>>,
+  TError = void,
+>(
+  bucket: string,
+  path: string,
+  params: StorageControllerDownloadFileParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof storageControllerDownloadFile>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof storageControllerDownloadFile>>,
+          TError,
+          Awaited<ReturnType<typeof storageControllerDownloadFile>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof orvalClient>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useStorageControllerDownloadFile<
+  TData = Awaited<ReturnType<typeof storageControllerDownloadFile>>,
+  TError = void,
+>(
+  bucket: string,
+  path: string,
+  params: StorageControllerDownloadFileParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof storageControllerDownloadFile>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof orvalClient>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+/**
+ * @summary Download a file with time-limited token
+ */
+
+export function useStorageControllerDownloadFile<
+  TData = Awaited<ReturnType<typeof storageControllerDownloadFile>>,
+  TError = void,
+>(
+  bucket: string,
+  path: string,
+  params: StorageControllerDownloadFileParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof storageControllerDownloadFile>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof orvalClient>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getStorageControllerDownloadFileQueryOptions(
+    bucket,
+    path,
+    params,
+    options,
+  );
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
 
 /**
  * @summary Get a file from storage (public)

--- a/core-api/package.json
+++ b/core-api/package.json
@@ -25,6 +25,7 @@
     "@ai-sdk/google": "^3.0.53",
     "@ai-sdk/openai": "^3.0.48",
     "@aws-sdk/client-s3": "^3.1048.0",
+    "@aws-sdk/s3-request-presigner": "^3.1075.0",
     "@grpc/grpc-js": "^1.14.2",
     "@grpc/proto-loader": "^0.8.0",
     "@grpc/reflection": "^1.0.4",

--- a/core-api/src/modules/reports/dto/reports.dto.ts
+++ b/core-api/src/modules/reports/dto/reports.dto.ts
@@ -26,6 +26,9 @@ export class ReportResponseDto {
 
   @ApiProperty()
   createdAt: Date;
+
+  @ApiProperty({ description: 'Presigned download URL (expires in 15 minutes)' })
+  downloadUrl: string;
 }
 
 export class GenerateSummaryReportBodyDto {

--- a/core-api/src/modules/reports/reports.service.ts
+++ b/core-api/src/modules/reports/reports.service.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
+import { STORAGE_BASE_PATH } from '@/common/constants/app.constants';
 import { generateToken } from '@/utils/genToken';
 import { getManyResponse } from '@/utils/getManyResponse';
 import { StorageService } from '@/modules/storage/storage.service';
@@ -71,7 +72,16 @@ export class ReportsService {
     qb.orderBy(sortColumn, sortOrder);
 
     const total = await qb.getCount();
-    const data = await qb.limit(limit).offset(offset).getMany();
+    const reports = await qb.limit(limit).offset(offset).getMany();
+
+    const data = reports.map((report) => {
+      const idx = report.path.indexOf('/');
+      const bucket = report.path.slice(0, idx);
+      const filePath = report.path.slice(idx + 1);
+      const token = this.storageService.generateDownloadToken(filePath, bucket);
+      const downloadUrl = `${STORAGE_BASE_PATH}/${bucket}/${encodeURIComponent(filePath)}/download?token=${token}`;
+      return { ...report, downloadUrl };
+    });
 
     return getManyResponse({ query, data, total });
   }
@@ -120,7 +130,7 @@ export class ReportsService {
 
     const pdfBuffer = await renderReportPdf(type, enrichedData);
 
-    const fileName = `report-${type.toLowerCase()}-${generateToken(8)}-${Date.now()}.pdf`;
+    const fileName = `report-${type.toLowerCase()}-${generateToken(24)}-${Date.now()}.pdf`;
     const { path: uploadPath } = await this.storageService.uploadFile(
       fileName,
       pdfBuffer,

--- a/core-api/src/modules/storage/storage.controller.ts
+++ b/core-api/src/modules/storage/storage.controller.ts
@@ -6,6 +6,7 @@ import {
   BadRequestException,
   Body,
   Controller,
+  ForbiddenException,
   Get,
   NotFoundException,
   Param,
@@ -194,6 +195,61 @@ export class StorageController {
   }
 
   @Public()
+  @Get(':bucket/:path/download')
+  @ApiOperation({ summary: 'Download a file with time-limited token' })
+  @ApiParam({ name: 'bucket', type: String, required: true })
+  @ApiParam({ name: 'path', type: String, required: true })
+  @ApiQuery({ name: 'token', type: String, required: true, description: 'Time-limited download token' })
+  @ApiResponse({
+    status: 200,
+    description: 'File downloaded successfully',
+    content: {
+      'application/octet-stream': {
+        schema: {
+          type: 'string',
+          format: 'binary',
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: 400, description: 'Invalid or expired token' })
+  @ApiResponse({ status: 404, description: 'File not found' })
+  async downloadFile(
+    @Param('bucket') bucket: string,
+    @Param('path') path: string,
+    @Query('token') token: string,
+    @Res({ passthrough: true })
+    res: { set: (headers: Record<string, string>) => void },
+  ): Promise<StreamableFile> {
+    if (!token) {
+      throw new BadRequestException('Download token is required');
+    }
+
+    // Verify token and extract bucket/path from it (not from URL params)
+    const verified = this.storageService.verifyDownloadToken(token);
+
+    // Token-embedded values take precedence over URL params
+    const cleanPath = verified.filePath;
+    const fileBucket = verified.bucket;
+
+    const file = await this.storageService.getFile(cleanPath, fileBucket);
+
+    const extension = cleanPath.split('.').pop()?.toLowerCase();
+    if (extension) {
+      const mimeType = this.getMimeType(extension);
+      if (mimeType) {
+        res.set({
+          'Content-Type': mimeType,
+          'Content-Disposition': `attachment; filename="${cleanPath.split('/').pop()}"`,
+          'Cache-Control': 'no-store',
+        });
+      }
+    }
+
+    return file;
+  }
+
+  @Public()
   @Get(':bucket/:path')
   @ApiOperation({ summary: 'Get a file from storage (public)' })
   @ApiParam({ name: 'bucket', type: String, required: true })
@@ -222,6 +278,10 @@ export class StorageController {
   ): Promise<StreamableFile> {
     if (!path) {
       throw new NotFoundException('File path is required');
+    }
+
+    if (this.storageService.isPrivateBucket(bucket)) {
+      throw new ForbiddenException('Access denied');
     }
 
     const cleanPath = path.replace(/^\/+/, '');

--- a/core-api/src/modules/storage/storage.controller.ts
+++ b/core-api/src/modules/storage/storage.controller.ts
@@ -199,7 +199,12 @@ export class StorageController {
   @ApiOperation({ summary: 'Download a file with time-limited token' })
   @ApiParam({ name: 'bucket', type: String, required: true })
   @ApiParam({ name: 'path', type: String, required: true })
-  @ApiQuery({ name: 'token', type: String, required: true, description: 'Time-limited download token' })
+  @ApiQuery({
+    name: 'token',
+    type: String,
+    required: true,
+    description: 'Time-limited download token',
+  })
   @ApiResponse({
     status: 200,
     description: 'File downloaded successfully',
@@ -299,72 +304,6 @@ export class StorageController {
     }
 
     return file;
-  }
-
-  @Public()
-  @Get('forward')
-  @ApiOperation({ summary: 'Forward an image from a URL' })
-  @ApiQuery({
-    name: 'url',
-    type: String,
-    required: true,
-    description: 'The URL of the image to forward',
-  })
-  @ApiResponse({
-    status: 200,
-    description: 'Image forwarded successfully',
-    content: {
-      'image/*': {
-        schema: {
-          type: 'string',
-          format: 'binary',
-        },
-      },
-    },
-  })
-  @ApiResponse({
-    status: 400,
-    description: 'Bad request - URL is required or invalid',
-  })
-  @ApiResponse({
-    status: 404,
-    description: 'Image not found at the provided URL',
-  })
-  async forwardImage(
-    @Query('url') url: string,
-    @Res({ passthrough: true })
-    res: { set: (headers: Record<string, string>) => void },
-  ): Promise<StreamableFile> {
-    // Validate URL
-    if (!url) {
-      throw new BadRequestException('URL query parameter is required');
-    }
-
-    try {
-      const { buffer, contentType } =
-        await this.storageService.forwardImage(url);
-
-      // Set the content type header
-      res.set({
-        'Content-Type': contentType,
-        'Cache-Control': `max-age=${CACHE_STATIC_RESOURCE}, no-transform`,
-      });
-
-      // Return the image as a StreamableFile
-      return new StreamableFile(buffer);
-    } catch (error) {
-      if (
-        error instanceof BadRequestException ||
-        error instanceof NotFoundException
-      ) {
-        throw error;
-      }
-
-      // Handle network errors or other unexpected errors
-      throw new BadRequestException(
-        'Failed to fetch image from the provided URL',
-      );
-    }
   }
 
   private getMimeType(extension?: string): string | undefined {

--- a/core-api/src/modules/storage/storage.service.ts
+++ b/core-api/src/modules/storage/storage.service.ts
@@ -15,6 +15,9 @@ import {
   PutObjectCommand,
   S3ServiceException,
 } from '@aws-sdk/client-s3';
+import { createHmac, randomBytes } from 'crypto';
+import { DEFAULT_ENCRYPTION_KEY } from '@/common/constants/app.constants';
+import { ConfigService } from '@nestjs/config';
 import { RustFsClient } from './rustfs.client';
 import { Readable } from 'stream';
 
@@ -31,10 +34,23 @@ export class StorageService implements OnModuleInit {
     'default',
   ];
 
-  constructor(private readonly rustFsClient: RustFsClient) {}
+  private readonly privateBuckets = ['reports', 'job-results'];
+
+  private readonly downloadSecret: string;
+
+  constructor(
+    private readonly rustFsClient: RustFsClient,
+    private readonly configService: ConfigService,
+  ) {
+    this.downloadSecret = this.configService.get<string>('DEFAULT_ENCRYPTION_KEY', DEFAULT_ENCRYPTION_KEY);
+  }
 
   async onModuleInit() {
     await this.ensureBucketsExist();
+  }
+
+  public isPrivateBucket(bucket: string): boolean {
+    return this.privateBuckets.includes(bucket);
   }
 
   private async ensureBucketsExist() {
@@ -115,6 +131,59 @@ export class StorageService implements OnModuleInit {
       throw new InternalServerErrorException(
         `Failed to get file: ${errorMessage}`,
       );
+    }
+  }
+
+  public generateDownloadToken(
+    filePath: string,
+    bucket: string = 'default',
+    expiresIn: number = 900,
+  ): string {
+    const cleanPath = filePath.replace(/^[./\s]+/, '');
+
+    if (!cleanPath || cleanPath.includes('..')) {
+      throw new BadRequestException('Invalid file path');
+    }
+
+    const exp = Math.floor(Date.now() / 1000) + expiresIn;
+    const nonce = randomBytes(16).toString('hex');
+    const payload = `${bucket}:${cleanPath}:${exp}:${nonce}`;
+    const signature = createHmac('sha256', this.downloadSecret)
+      .update(payload)
+      .digest('hex');
+
+    return Buffer.from(`${payload}:${signature}`).toString('base64url');
+  }
+
+  public verifyDownloadToken(
+    token: string,
+  ): { bucket: string; filePath: string } {
+    try {
+      const decoded = Buffer.from(token, 'base64url').toString('utf8');
+      const parts = decoded.split(':');
+      if (parts.length !== 5) {
+        throw new Error('Invalid token format');
+      }
+
+      const [bucket, filePath, expStr, nonce, signature] = parts;
+      const exp = parseInt(expStr, 10);
+
+      if (Math.floor(Date.now() / 1000) > exp) {
+        throw new Error('Token expired');
+      }
+
+      const payload = `${bucket}:${filePath}:${expStr}:${nonce}`;
+      const expectedSignature = createHmac('sha256', this.downloadSecret)
+        .update(payload)
+        .digest('hex');
+
+      if (signature !== expectedSignature) {
+        throw new Error('Invalid signature');
+      }
+
+      return { bucket, filePath };
+    } catch {
+      throw new BadRequestException('Invalid or expired download token');
     }
   }
 

--- a/core-api/src/utils/genToken.ts
+++ b/core-api/src/utils/genToken.ts
@@ -1,7 +1,6 @@
 import { customAlphabet } from 'nanoid';
 
-const alphabet =
-  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+const alphabet = 'abcdefghijklmnopqrstuvwxyz0123456789';
 
 /**
  * Generates a random token string using a specific alphabet and length.

--- a/package-lock.json
+++ b/package-lock.json
@@ -151,6 +151,7 @@
         "@ai-sdk/google": "^3.0.53",
         "@ai-sdk/openai": "^3.0.48",
         "@aws-sdk/client-s3": "^3.1048.0",
+        "@aws-sdk/s3-request-presigner": "^3.1075.0",
         "@grpc/grpc-js": "^1.14.2",
         "@grpc/proto-loader": "^0.8.0",
         "@grpc/reflection": "^1.0.4",
@@ -1179,15 +1180,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.974.15",
+      "version": "3.974.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.23.tgz",
+      "integrity": "sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@aws-sdk/xml-builder": "^3.972.26",
+        "@aws-sdk/types": "^3.973.13",
+        "@aws-sdk/xml-builder": "^3.972.31",
         "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.5",
-        "@smithy/signature-v4": "^5.4.5",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -1441,13 +1444,32 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.30",
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1075.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1075.0.tgz",
+      "integrity": "sha512-++ftTvAGZSTuzFVHEPk8lLi7mybBD8PzJ9USWBvwnE4kSrXOyqYVJ5Ixd06xUEWS/xsrhpkI07mzCLGIxrRymA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.9",
-        "@smithy/signature-v4": "^5.4.5",
-        "@smithy/types": "^4.14.2",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
+      "integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1470,10 +1492,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.9",
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
+      "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1491,11 +1515,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.26",
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.31.tgz",
+      "integrity": "sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.14.2",
-        "fast-xml-parser": "5.7.3",
+        "@smithy/types": "^4.14.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6989,16 +7014,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@nodable/entities": {
-      "version": "2.1.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "license": "MIT",
@@ -10062,11 +10077,13 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.24.5",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.26.0.tgz",
+      "integrity": "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.2",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10120,11 +10137,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.4.5",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.2.tgz",
+      "integrity": "sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.24.5",
-        "@smithy/types": "^4.14.2",
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -10132,7 +10151,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.14.2",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -17499,39 +17520,6 @@
         "fast-string-width": "^3.0.2"
       }
     },
-    "node_modules/fast-xml-builder": {
-      "version": "1.2.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.5.0",
-        "xml-naming": "^0.1.0"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.7.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.7",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "license": "ISC",
@@ -23942,19 +23930,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "dev": true,
@@ -26900,16 +26875,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/strnum": {
-      "version": "2.3.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/strtok3": {
       "version": "10.3.5",
@@ -29993,19 +29958,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/xml-naming": {
-      "version": "0.1.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlchars": {


### PR DESCRIPTION
Add secure file download mechanism using time-limited tokens for private buckets in `core-api`, and update `console` to use these tokens for report downloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Report downloads now use secure, token-based presigned URLs that automatically expire after 15 minutes, enhancing data protection
  * Added access controls to prevent unauthorized public access to private storage buckets

* **Chores**
  * Updated dependencies and internal utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->