### PR TITLE
fix(console,core-api): align notification asset counts with detail screen and filter null status codes

### DIFF
--- a/console/src/pages/assets/components/status-code-assets-column.tsx
+++ b/console/src/pages/assets/components/status-code-assets-column.tsx
@@ -4,8 +4,8 @@ import type { ColumnDef } from '@tanstack/react-table';
 
 export const statusCodeAssetsColumn: ColumnDef<GetStatusCodeAssetsDTO>[] = [
   {
-    accessorKey: 'port',
-    header: 'Port',
+    accessorKey: 'statusCode',
+    header: 'Status Code',
     enableHiding: false,
     size: 500,
     cell: ({ row }) => {

--- a/core-api/src/i18n/en/notification.json
+++ b/core-api/src/i18n/en/notification.json
@@ -1,5 +1,5 @@
 {
   "WORKSPACE_CREATED": "Workspace {name} created",
   "VULNERABILITY_ANALYSIS_COMPLETED": "Vulnerability analysis completed for {name}",
-  "ASSET_NEW_DETECT": "New assets discovered for {targetValue}: {hosts, plural, =0 {} one {# host} other {# hosts}}{ports, plural, =0 {} one { # port} other { # ports}}{tech, plural, =0 {} one { # technology} other { # technologies}}"
+  "ASSET_NEW_DETECT": "New assets discovered for {targetValue}: {hosts, plural, =0 {} one {# host} other {# hosts}}{ports, plural, =0 {} one { # port} other { # ports}}{services, plural, =0 {} one { # service} other { # services}}{tech, plural, =0 {} one { # technology} other { # technologies}}"
 }

--- a/core-api/src/modules/assets/assets.service.ts
+++ b/core-api/src/modules/assets/assets.service.ts
@@ -682,16 +682,9 @@ export class AssetsService {
         '"statusCodeAssets"."statusCode"',
         'COUNT(DISTINCT asset_service.id) as "assetCount"',
       ])
-      .groupBy('"statusCodeAssets"."statusCode"');
-
-    if (query.value) {
-      queryBuilder.andWhere(
-        '"statusCodeAssets"."statusCode"::text ILIKE :value',
-        {
-          value: `%${query.value}%`,
-        },
-      );
-    }
+      .groupBy('"statusCodeAssets"."statusCode"')
+      .andWhere('"statusCodeAssets"."statusCode" IS NOT NULL')
+      .andWhere('"statusCodeAssets"."statusCode" != 0');
 
     if (query.value) {
       queryBuilder.andWhere(

--- a/core-api/src/modules/statistic/statistic.service.ts
+++ b/core-api/src/modules/statistic/statistic.service.ts
@@ -64,6 +64,7 @@ interface StatisticFilter {
 interface StatisticSnapshot {
   hosts: number;
   ports: number;
+  services: number;
   techs: number;
 }
 
@@ -523,6 +524,54 @@ export class StatisticService {
       .createQueryBuilder()
       .select('sq."workspaceId"', 'workspaceId')
       .addSelect('COUNT(DISTINCT sq.tech)', 'count') // Count distinct technologies
+      .from(`(${subQuery.getQuery()})`, 'sq')
+      .setParameters(subQuery.getParameters())
+      .groupBy('sq."workspaceId"')
+      .getRawMany<{ workspaceId: string; count: string }>();
+  }
+
+  /**
+   * Retrieves the count of unique hosts (distinct asset.value) for each workspace.
+   * Counts only hosts that have at least one AssetService, matching the frontend
+   * host-assets-tab counting logic.
+   */
+  async getHostCounts(filter: StatisticFilter) {
+    const { workspaceIds, targetId, startDate, endDate } = filter;
+    const subQuery = this.dataSource
+      .createQueryBuilder()
+      .select('wt.workspaceId', 'workspaceId')
+      .addSelect('asset.value', 'host')
+      .from(AssetService, 'assetService')
+      .innerJoin('assetService.asset', 'asset')
+      .innerJoin('asset.target', 'target')
+      .innerJoin('target.workspaceTargets', 'wt')
+      .where('1=1')
+      .andWhere('asset.value IS NOT NULL');
+
+    if (workspaceIds?.length) {
+      subQuery.andWhere('wt.workspaceId IN (:...workspaceIds)', {
+        workspaceIds,
+      });
+    }
+    if (targetId) {
+      subQuery.andWhere('target.id = :targetId', { targetId });
+    }
+    if (startDate) {
+      subQuery.andWhere('"assetService"."createdAt" >= :startDate', {
+        startDate,
+      });
+    }
+    if (endDate) {
+      subQuery.andWhere('"assetService"."createdAt" <= :endDate', {
+        endDate,
+      });
+    }
+
+    // Main query to count distinct hosts (asset.value) for each workspaceId
+    return this.dataSource
+      .createQueryBuilder()
+      .select('sq."workspaceId"', 'workspaceId')
+      .addSelect('COUNT(DISTINCT sq.host)', 'count')
       .from(`(${subQuery.getQuery()})`, 'sq')
       .setParameters(subQuery.getParameters())
       .groupBy('sq."workspaceId"')
@@ -1217,11 +1266,14 @@ export class StatisticService {
   async takeSnapshotStatisticTarget(
     targetId: string,
   ): Promise<StatisticSnapshot> {
-    const [hosts, ports, techs] = await Promise.all([
-      this.getAssetCounts({ targetId }).then((res) =>
+    const [hosts, ports, services, techs] = await Promise.all([
+      this.getHostCounts({ targetId }).then((res) =>
         res.length > 0 ? Number(res[0].count) : 0,
       ),
       this.getPortCounts({ targetId }).then((res) =>
+        res.length > 0 ? Number(res[0].count) : 0,
+      ),
+      this.getServiceCounts({ targetId }).then((res) =>
         res.length > 0 ? Number(res[0].count) : 0,
       ),
       this.getTechCounts({ targetId }).then((res) =>
@@ -1229,7 +1281,7 @@ export class StatisticService {
       ),
     ]);
 
-    return { hosts, ports, techs };
+    return { hosts, ports, services, techs };
   }
 
   @OnEvent(EventTriggerType.WORKFLOW_START)
@@ -1300,6 +1352,7 @@ export class StatisticService {
             metadata: {
               hosts: String(diffs.hosts ?? 0),
               ports: String(diffs.ports ?? 0),
+              services: String(diffs.services ?? 0),
               tech: String(diffs.techs ?? 0),
               targetValue: job.asset.target.value,
               targetId: job.asset.target.id,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Asset status-code reporting now shows **Status Code** in the assets table.
  * Notifications for new asset detections now include **services** in the summary counts.
  * Statistics now track **service counts** alongside host, port, and technology metrics.

* **Bug Fixes**
  * Improved status-code asset results by excluding empty or invalid entries from the list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->