### PR TITLE
fix(worker): add arm64 Docker image support via cross-compilation

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -70,7 +70,7 @@ jobs:
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx with cache support
         run: |

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -69,6 +69,9 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx with cache support
         run: |
           docker buildx create --name mybuilder --driver docker-container --use
@@ -77,7 +80,7 @@ jobs:
       - name: Build and push
         run: |
           docker buildx build \
-            --platform linux/amd64 \
+            --platform linux/amd64,linux/arm64 \
             --push \
             --cache-from=type=registry,ref=${{ env.IMAGE_NAME }}-${{ matrix.service }}:buildcache \
             --cache-to=type=registry,ref=${{ env.IMAGE_NAME }}-${{ matrix.service }}:buildcache,mode=max \

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -87,6 +87,9 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx with cache support
         run: |
           docker buildx create --name mybuilder --driver docker-container --use
@@ -95,7 +98,7 @@ jobs:
       - name: Build and push
         run: |
           docker buildx build \
-            --platform linux/amd64 \
+            --platform linux/amd64,linux/arm64 \
             --push \
             --cache-from=type=registry,ref=${{ env.IMAGE_NAME }}-${{ matrix.service }}:buildcache \
             --cache-to=type=registry,ref=${{ env.IMAGE_NAME }}-${{ matrix.service }}:buildcache,mode=max \

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -88,7 +88,7 @@ jobs:
           password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx with cache support
         run: |

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,5 +1,7 @@
-# Stage 1: Build
-FROM golang:1.26-alpine AS builder
+# Stage 1: Build — always runs on the native build platform for fast cross-compilation
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
+
+ARG TARGETARCH
 
 WORKDIR /app
 
@@ -15,8 +17,8 @@ RUN go mod download
 # Copy source code
 COPY . .
 
-# Build static binary with optimizations from the new APP entrypoint
-RUN CGO_ENABLED=0 GOOS=linux go build \
+# Cross-compile for the target architecture; CGO_ENABLED=0 makes this dependency-free
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build \
     -ldflags='-w -s -extldflags "-static"' \
     -o oasm-worker ./cmd/app
 


### PR DESCRIPTION
## Problem

The worker Docker image is only published for `linux/amd64`. On Apple Silicon Macs, after oasm-platform/oasm-docker#3 removed the hardcoded `platform: linux/amd64` from the compose file so the worker could run as native arm64, Docker still falls back to the amd64 image (no arm64 manifest exists), which then panics immediately under Rosetta:

```
panic: [launcher] Failed to get the debug url: The hardware on this system lacks support for the sse3 instruction set.
```

## Fix

**`worker/Dockerfile`** — cross-compile the Go binary natively on the build host instead of under QEMU:
- Pin the builder stage to `--platform=$BUILDPLATFORM` so Go runs on the native CI runner (amd64)
- Inject `ARG TARGETARCH` and pass `GOARCH=$TARGETARCH` to the build command
- `CGO_ENABLED=0` makes this cross-compilation fully dependency-free

**`build-nightly.yml` / `build-release.yml`** — publish arm64 images:
- Add `docker/setup-qemu-action@v3` (required for the `apt-get` runtime layer on arm64)
- Extend `--platform` from `linux/amd64` → `linux/amd64,linux/arm64`

The cross-compilation approach means Go compilation still runs at native speed on GitHub's amd64 runners; QEMU is only used for the lightweight `apt-get install` in the runtime stage.

## Test plan

- [x] Built `linux/arm64` image locally on Apple M-series with `docker buildx build --platform linux/arm64 --load`
- [x] Worker starts without SSE3 panic
- [x] Worker connects to `core-api`, downloads `linux_arm64` tool binaries (dnsx, httpx, naabu, nuclei, subfinder) via oasm-platform/oasm-sdk-go#10 arch filtering
- [x] Worker begins executing jobs immediately

## Related

- oasm-platform/oasm-docker#3 — removed `platform: linux/amd64` from compose so the worker runs as native arm64 (this PR completes that fix by publishing the arm64 image)
- oasm-platform/open-asm#438 — added `linux/arm64` tool binaries to the registry
- oasm-platform/oasm-sdk-go#10 — filters tool downloads by CPU arch so amd64 and arm64 workers each pull the correct binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for building and publishing images for both AMD64 and ARM64 architectures.
  * Updated the worker image build process to produce architecture-specific binaries during Docker builds.
* **Chores**
  * Enabled cross-platform Docker builds by setting up QEMU in nightly and release workflows.
  * Updated Docker Buildx to build for multiple platforms (AMD64 and ARM64) when publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->