### PR TITLE
fix(notifications): filter notifications by workspace

### DIFF
--- a/console/src/services/apis/gen/queries.ts
+++ b/console/src/services/apis/gen/queries.ts
@@ -1725,9 +1725,9 @@ export type NotificationResponseDto = {
   id: string;
   status: NotificationResponseDtoStatus;
   createdAt: string;
-  updatedAt: string;
   message: string;
   url: string;
+  workspaceId?: string;
 };
 
 export type GetManyNotificationResponseDtoDto = {
@@ -32086,3 +32086,225 @@ export function useStorageControllerGetFile<
 
   return { ...query, queryKey: queryOptions.queryKey };
 }
+
+export const mcpControllerHandleSSE = (
+  options?: SecondParameter<typeof orvalClient>,
+  signal?: AbortSignal,
+) => {
+  return orvalClient<void>({ url: `/api/mcp`, method: 'GET', signal }, options);
+};
+
+export const getMcpControllerHandleSSEQueryKey = () => {
+  return [`/api/mcp`] as const;
+};
+
+export const getMcpControllerHandleSSEQueryOptions = <
+  TData = Awaited<ReturnType<typeof mcpControllerHandleSSE>>,
+  TError = unknown,
+>(options?: {
+  query?: Partial<
+    UseQueryOptions<
+      Awaited<ReturnType<typeof mcpControllerHandleSSE>>,
+      TError,
+      TData
+    >
+  >;
+  request?: SecondParameter<typeof orvalClient>;
+}) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ?? getMcpControllerHandleSSEQueryKey();
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof mcpControllerHandleSSE>>
+  > = ({ signal }) => mcpControllerHandleSSE(requestOptions, signal);
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof mcpControllerHandleSSE>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type McpControllerHandleSSEQueryResult = NonNullable<
+  Awaited<ReturnType<typeof mcpControllerHandleSSE>>
+>;
+export type McpControllerHandleSSEQueryError = unknown;
+
+export function useMcpControllerHandleSSE<
+  TData = Awaited<ReturnType<typeof mcpControllerHandleSSE>>,
+  TError = unknown,
+>(
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof mcpControllerHandleSSE>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof mcpControllerHandleSSE>>,
+          TError,
+          Awaited<ReturnType<typeof mcpControllerHandleSSE>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof orvalClient>;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useMcpControllerHandleSSE<
+  TData = Awaited<ReturnType<typeof mcpControllerHandleSSE>>,
+  TError = unknown,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof mcpControllerHandleSSE>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof mcpControllerHandleSSE>>,
+          TError,
+          Awaited<ReturnType<typeof mcpControllerHandleSSE>>
+        >,
+        'initialData'
+      >;
+    request?: SecondParameter<typeof orvalClient>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useMcpControllerHandleSSE<
+  TData = Awaited<ReturnType<typeof mcpControllerHandleSSE>>,
+  TError = unknown,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof mcpControllerHandleSSE>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof orvalClient>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+
+export function useMcpControllerHandleSSE<
+  TData = Awaited<ReturnType<typeof mcpControllerHandleSSE>>,
+  TError = unknown,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof mcpControllerHandleSSE>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof orvalClient>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getMcpControllerHandleSSEQueryOptions(options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  return { ...query, queryKey: queryOptions.queryKey };
+}
+
+export const mcpControllerHandleMessage = (
+  options?: SecondParameter<typeof orvalClient>,
+  signal?: AbortSignal,
+) => {
+  return orvalClient<void>(
+    { url: `/api/mcp/message`, method: 'POST', signal },
+    options,
+  );
+};
+
+export const getMcpControllerHandleMessageMutationOptions = <
+  TError = unknown,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof mcpControllerHandleMessage>>,
+    TError,
+    void,
+    TContext
+  >;
+  request?: SecondParameter<typeof orvalClient>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof mcpControllerHandleMessage>>,
+  TError,
+  void,
+  TContext
+> => {
+  const mutationKey = ['mcpControllerHandleMessage'];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      'mutationKey' in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof mcpControllerHandleMessage>>,
+    void
+  > = () => {
+    return mcpControllerHandleMessage(requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type McpControllerHandleMessageMutationResult = NonNullable<
+  Awaited<ReturnType<typeof mcpControllerHandleMessage>>
+>;
+
+export type McpControllerHandleMessageMutationError = unknown;
+
+export const useMcpControllerHandleMessage = <
+  TError = unknown,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof mcpControllerHandleMessage>>,
+      TError,
+      void,
+      TContext
+    >;
+    request?: SecondParameter<typeof orvalClient>;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof mcpControllerHandleMessage>>,
+  TError,
+  void,
+  TContext
+> => {
+  return useMutation(
+    getMcpControllerHandleMessageMutationOptions(options),
+    queryClient,
+  );
+};

--- a/core-api/src/modules/notifications/dto/notification.dto.ts
+++ b/core-api/src/modules/notifications/dto/notification.dto.ts
@@ -12,11 +12,11 @@ export class NotificationResponseDto {
   createdAt: Date;
 
   @ApiProperty()
-  updatedAt: Date;
-
-  @ApiProperty()
   message: string;
 
   @ApiProperty()
   url: string;
+
+  @ApiProperty({ required: false })
+  workspaceId?: string;
 }

--- a/core-api/src/modules/notifications/notifications.controller.ts
+++ b/core-api/src/modules/notifications/notifications.controller.ts
@@ -16,7 +16,7 @@ import { NotificationsService } from './notifications.service';
 import { I18nLang } from 'nestjs-i18n';
 import { AuthGuard } from '@/common/guards/auth.guard';
 import { CreateNotificationDto } from './dto/create-notification.dto';
-import { UserContext } from '@/common/decorators/app.decorator';
+import { UserContext, WorkspaceId } from '@/common/decorators/app.decorator';
 import { Doc } from '@/common/doc/doc.decorator';
 import { GetManyResponseDto } from '@/utils/getManyResponse';
 import { NotificationResponseDto } from './dto/notification.dto';
@@ -35,14 +35,23 @@ export class NotificationsController {
     response: {
       serialization: GetManyResponseDto(NotificationResponseDto),
     },
+    request: {
+      getWorkspaceId: true,
+    },
   })
   @Get()
   async getNotifications(
     @UserContext() user: UserContextPayload,
+    @WorkspaceId() workspaceId: string,
     @Query() query: GetManyBaseQueryParams,
     @I18nLang() lang: string,
   ) {
-    return this.notificationsService.getNotifications(user.id, query, lang);
+    return this.notificationsService.getNotifications(
+      user.id,
+      workspaceId,
+      query,
+      lang,
+    );
   }
 
   @Doc({

--- a/core-api/src/modules/notifications/notifications.service.ts
+++ b/core-api/src/modules/notifications/notifications.service.ts
@@ -34,6 +34,7 @@ export class NotificationsService {
 
   async getNotifications(
     userId: string,
+    workspaceId: string,
     query: GetManyBaseQueryParams,
     lang: string = 'en',
   ) {
@@ -42,6 +43,10 @@ export class NotificationsService {
       .createQueryBuilder('recipient')
       .leftJoinAndSelect('recipient.notification', 'notification')
       .where('recipient.userId = :userId', { userId })
+      .andWhere(
+        '(notification.workspaceId = :workspaceId OR notification.workspaceId IS NULL)',
+        { workspaceId },
+      )
       .orderBy('recipient.createdAt', 'DESC')
       .select([
         'recipient.id',
@@ -50,11 +55,12 @@ export class NotificationsService {
         'notification.id',
         'notification.type',
         'notification.metadata',
+        'notification.workspaceId',
       ])
       .skip(offset)
       .take(query.limit)
       .getManyAndCount();
-    const data = notifications.map((n) => {
+    const data: NotificationResponseDto[] = notifications.map((n) => {
       const key = `notification.${n.notification.type}`;
       const message = this.i18n.translate<string>(key, {
         lang,
@@ -71,7 +77,8 @@ export class NotificationsService {
         createdAt: n.createdAt,
         message,
         url,
-      } as NotificationResponseDto;
+        workspaceId: n.notification.workspaceId ?? undefined,
+      };
     });
     return getManyResponse({
       query,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notifications are now filtered by workspace, so users only see relevant items for the selected workspace.
  * Notification responses now include a workspace identifier when available.

* **Bug Fixes**
  * Improved notification retrieval to better match workspace-specific context.

* **Breaking Changes**
  * The notification response no longer includes the previous update timestamp field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->