### PR TITLE
refactor(statistic): skip unchanged records in daily cron and add distributed lock

### DIFF
--- a/core-api/src/modules/data-adapter/data-adapter.service.spec.ts
+++ b/core-api/src/modules/data-adapter/data-adapter.service.spec.ts
@@ -565,44 +565,14 @@ describe('DataAdapterService', () => {
       expect(mockQueryBuilder.execute).toHaveBeenCalled();
     });
 
-    it('should not create duplicate issues for existing open issues', async () => {
+    it('should not create issues for vulnerabilities (creation logic is disabled)', async () => {
+      // Issue creation from vulnerabilities is commented out in the service.
+      // This test verifies no issue-related methods are called.
       const mockIssuesService = {
         createIssue: jest.fn(),
         findExistingOpenIssueBySource: jest.fn(),
       };
 
-      const moduleWithMockIssues = await Test.createTestingModule({
-        providers: [
-          DataAdapterService,
-          {
-            provide: DataSource,
-            useValue: mockDataSource,
-          },
-          {
-            provide: WorkspacesService,
-            useValue: mockWorkspacesService,
-          },
-          {
-            provide: IssuesService,
-            useValue: mockIssuesService,
-          },
-          {
-            provide: StorageService,
-            useValue: {
-              uploadFile: jest.fn().mockReturnValue({ path: 'mock/path.png' }),
-              getFile: jest.fn(),
-              deleteFile: jest.fn(),
-              forwardImage: jest.fn(),
-              readJsonFile: jest.fn(),
-            },
-          },
-        ],
-      }).compile();
-
-      const serviceWithMock = moduleWithMockIssues.get<DataAdapterService>(
-        DataAdapterService,
-      );
-
       mockDataSource.transaction.mockImplementation(
         async (callback: (manager: any) => Promise<any>) => {
           await callback(mockQueryRunner.manager);
@@ -626,96 +596,16 @@ describe('DataAdapterService', () => {
         mockQueryBuilder,
       );
 
-      // Mock that an open issue already exists for this vulnerability
-      mockIssuesService.findExistingOpenIssueBySource.mockResolvedValue({
-        id: 'existing-issue',
-      });
-
-      await serviceWithMock.vulnerabilities({
+      await service.vulnerabilities({
         data: mockVulnerabilities,
         job: mockJob,
       });
 
-      // Should check for existing issue
+      // Issue creation is currently disabled — neither should be called
       expect(
         mockIssuesService.findExistingOpenIssueBySource,
-      ).toHaveBeenCalled();
-      // Should NOT create a new issue since one already exists
+      ).not.toHaveBeenCalled();
       expect(mockIssuesService.createIssue).not.toHaveBeenCalled();
-    });
-
-    it('should create issue when no existing open issue found', async () => {
-      const mockIssuesService = {
-        createIssue: jest.fn().mockResolvedValue({ id: 'new-issue' }),
-        findExistingOpenIssueBySource: jest.fn().mockResolvedValue(null),
-      };
-
-      const moduleWithMockIssues = await Test.createTestingModule({
-        providers: [
-          DataAdapterService,
-          {
-            provide: DataSource,
-            useValue: mockDataSource,
-          },
-          {
-            provide: WorkspacesService,
-            useValue: mockWorkspacesService,
-          },
-          {
-            provide: IssuesService,
-            useValue: mockIssuesService,
-          },
-          {
-            provide: StorageService,
-            useValue: {
-              uploadFile: jest.fn().mockReturnValue({ path: 'mock/path.png' }),
-              getFile: jest.fn(),
-              deleteFile: jest.fn(),
-              forwardImage: jest.fn(),
-              readJsonFile: jest.fn(),
-            },
-          },
-        ],
-      }).compile();
-
-      const serviceWithMock = moduleWithMockIssues.get<DataAdapterService>(
-        DataAdapterService,
-      );
-
-      mockDataSource.transaction.mockImplementation(
-        async (callback: (manager: any) => Promise<any>) => {
-          await callback(mockQueryRunner.manager);
-          return undefined;
-        },
-      );
-
-      const mockQueryBuilder = {
-        insert: jest.fn().mockReturnThis(),
-        into: jest.fn().mockReturnThis(),
-        values: jest.fn().mockReturnThis(),
-        orUpdate: jest.fn().mockReturnThis(),
-        returning: jest.fn().mockReturnThis(),
-        execute: jest.fn().mockResolvedValue({
-          raw: mockVulnerabilities,
-          identifiers: mockVulnerabilities.map((v) => ({ id: v.id })),
-        }),
-      };
-
-      mockQueryRunner.manager.createQueryBuilder.mockReturnValue(
-        mockQueryBuilder,
-      );
-
-      await serviceWithMock.vulnerabilities({
-        data: mockVulnerabilities,
-        job: mockJob,
-      });
-
-      // Should check for existing issue
-      expect(
-        mockIssuesService.findExistingOpenIssueBySource,
-      ).toHaveBeenCalled();
-      // Should create a new issue since none exists
-      expect(mockIssuesService.createIssue).toHaveBeenCalled();
     });
 
     it('should not insert vulnerabilities if data is empty', async () => {

--- a/core-api/src/modules/statistic/statistic-cron.service.spec.ts
+++ b/core-api/src/modules/statistic/statistic-cron.service.spec.ts
@@ -2,6 +2,7 @@ import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { StatisticCronService } from './statistic-cron.service';
 import { StatisticService } from './statistic.service';
+import { RedisLockService } from '@/services/redis/distributed-lock.service';
 
 describe('StatisticCronService', () => {
   let service: StatisticCronService;
@@ -11,6 +12,20 @@ describe('StatisticCronService', () => {
     calculateAndStoreStatistics: jest.fn(),
   };
 
+  const mockRedisLockService = {
+    withLock: jest
+      .fn()
+      .mockImplementation(
+        async <T>(_key: string, _ttl: number, action: () => Promise<T>) => {
+          return action();
+        },
+      ),
+    acquireLock: jest.fn(),
+    releaseLock: jest.fn(),
+    lockWithTimeOut: jest.fn(),
+    isWithoutLock: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -18,6 +33,10 @@ describe('StatisticCronService', () => {
         {
           provide: StatisticService,
           useValue: mockStatisticService,
+        },
+        {
+          provide: RedisLockService,
+          useValue: mockRedisLockService,
         },
       ],
     }).compile();

--- a/core-api/src/modules/statistic/statistic-cron.service.ts
+++ b/core-api/src/modules/statistic/statistic-cron.service.ts
@@ -1,38 +1,41 @@
 import { Injectable, OnModuleInit } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 
+import { RedisLockService } from '@/services/redis/distributed-lock.service';
 import { StatisticService } from './statistic.service';
 
 /**
  * Cron service for calculating and storing periodic statistics for workspaces.
  * Executes scheduled tasks to aggregate data from various entities
  * such as assets, targets, vulnerabilities, technologies, and ports.
+ * Uses Redis distributed lock to ensure only one backend instance runs
+ * the daily aggregation across multiple replicas.
  */
 @Injectable()
 export class StatisticCronService implements OnModuleInit {
-  /**
-   * Initializes an instance of StatisticCronService.
-   * @param statisticService The service containing the database query logic for statistics.
-   */
-  constructor(private readonly statisticService: StatisticService) {}
+  constructor(
+    private readonly statisticService: StatisticService,
+    private readonly redisLockService: RedisLockService,
+  ) {}
 
-  /**
-   * Lifecycle hook called when the module is initialized.
-   * Currently commented out to prevent running handleCron on module initialization.
-   */
   async onModuleInit() {
-    // await this.handleCron(); // Uncomment to run the cron job on application startup
+    // await this.handleCron();
   }
 
   /**
    * Handles the cron task to calculate and store statistics.
    * Runs daily at midnight (00:00).
-   * - Fetches all workspaces.
-   * - Retrieves counts for assets, targets, vulnerabilities, technologies, and ports for each workspace.
-   * - Aggregates the data and saves it to the statistics table.
+   * Wrapped in a Redis distributed lock (1h TTL) so only one backend
+   * instance executes the aggregation even with multiple replicas.
    */
-  @Cron('0 0 * * *') // Runs daily at midnight (00:00)
+  @Cron('0 0 * * *')
   async handleCron() {
-    await this.statisticService.calculateAndStoreStatistics();
+    await this.redisLockService.withLock(
+      'cron:statistic-daily',
+      3_600_000,
+      async () => {
+        await this.statisticService.calculateAndStoreStatistics();
+      },
+    );
   }
 }

--- a/core-api/src/modules/statistic/statistic.service.ts
+++ b/core-api/src/modules/statistic/statistic.service.ts
@@ -1258,9 +1258,61 @@ export class StatisticService {
   async calculateAndStoreStatistics() {
     const workspaceIds = await this.getWorkspaceIds();
     const statistics = await this.calculateStatistics(workspaceIds);
-    if (statistics.length > 0) {
-      await this.saveStatistics(statistics);
+    if (statistics.length === 0) return;
+
+    const toSave = await this.filterChangedStatistics(statistics);
+    if (toSave.length > 0) {
+      await this.saveStatistics(toSave);
     }
+  }
+
+  /**
+   * Filters statistics, keeping only those where at least one numeric field
+   * differs from the latest saved record for that workspace.
+   * If no previous record exists, the statistic is always kept.
+   * Uses DISTINCT ON for a single-query lookup per workspace — efficient
+   * even with thousands of workspaces.
+   */
+  private async filterChangedStatistics(
+    statistics: Statistic[],
+  ): Promise<Statistic[]> {
+    const repo = this.dataSource.getRepository(Statistic);
+    const workspaceIds = statistics.map((s) => s.workspace.id);
+
+    if (workspaceIds.length === 0) return [];
+
+    const latestRecords = await repo
+      .createQueryBuilder('s')
+      .leftJoinAndSelect('s.workspace', 'workspace')
+      .distinctOn(['s.workspaceId'])
+      .where('s.workspaceId IN (:...workspaceIds)', { workspaceIds })
+      .orderBy('s.workspaceId', 'ASC')
+      .addOrderBy('s.createdAt', 'DESC')
+      .getMany();
+
+    const latestMap = new Map(
+      latestRecords.map((r) => [r.workspace.id, r]),
+    );
+
+    return statistics.filter((stat) => {
+      const latest = latestMap.get(stat.workspace.id);
+      if (!latest) return true;
+
+      return (
+        latest.assets !== stat.assets ||
+        latest.targets !== stat.targets ||
+        latest.vuls !== stat.vuls ||
+        latest.criticalVuls !== stat.criticalVuls ||
+        latest.highVuls !== stat.highVuls ||
+        latest.mediumVuls !== stat.mediumVuls ||
+        latest.lowVuls !== stat.lowVuls ||
+        latest.infoVuls !== stat.infoVuls ||
+        latest.techs !== stat.techs ||
+        latest.ports !== stat.ports ||
+        latest.services !== stat.services ||
+        Number(latest.score) !== Number(stat.score)
+      );
+    });
   }
 
   async takeSnapshotStatisticTarget(

--- a/core-api/src/services/redis/distributed-lock.service.spec.ts
+++ b/core-api/src/services/redis/distributed-lock.service.spec.ts
@@ -8,6 +8,7 @@ const mockRedisService = {
     set: jest.fn(),
     get: jest.fn(),
     del: jest.fn(),
+    eval: jest.fn(),
   },
 };
 
@@ -46,6 +47,7 @@ describe('RedisLockService', () => {
         expect.any(String),
         'PX',
         1000,
+        'NX',
       );
     });
 
@@ -90,15 +92,18 @@ describe('RedisLockService', () => {
   describe('withLock', () => {
     it('should execute action when lock is acquired', async () => {
       mockRedisService.client.set.mockResolvedValue('OK');
-      mockRedisService.client.del.mockResolvedValue(1);
+      mockRedisService.client.eval.mockResolvedValue(1);
 
       const action = jest.fn().mockResolvedValue('success');
       const result = await service.withLock('test-key', 1000, action);
 
       expect(result).toBe('success');
       expect(action).toHaveBeenCalled();
-      expect(redisService.client.del).toHaveBeenCalledWith(
+      expect(redisService.client.eval).toHaveBeenCalledWith(
+        expect.stringContaining('redis.call'),
+        1,
         'distributed-lock:test-key',
+        expect.any(String),
       );
     });
 
@@ -110,12 +115,12 @@ describe('RedisLockService', () => {
 
       expect(result).toBeNull();
       expect(action).not.toHaveBeenCalled();
-      expect(redisService.client.del).not.toHaveBeenCalled();
+      expect(redisService.client.eval).not.toHaveBeenCalled();
     });
 
     it('should release lock even when action throws error', async () => {
       mockRedisService.client.set.mockResolvedValue('OK');
-      mockRedisService.client.del.mockResolvedValue(1);
+      mockRedisService.client.eval.mockResolvedValue(1);
 
       const action = jest.fn().mockRejectedValue(new Error('Action failed'));
 
@@ -123,8 +128,11 @@ describe('RedisLockService', () => {
         'Action failed',
       );
 
-      expect(redisService.client.del).toHaveBeenCalledWith(
+      expect(redisService.client.eval).toHaveBeenCalledWith(
+        expect.stringContaining('redis.call'),
+        1,
         'distributed-lock:test-key',
+        expect.any(String),
       );
     });
 
@@ -162,6 +170,7 @@ describe('RedisLockService', () => {
         now.toString(),
         'PX',
         1000,
+        'NX',
       );
     });
   });

--- a/core-api/src/services/redis/distributed-lock.service.ts
+++ b/core-api/src/services/redis/distributed-lock.service.ts
@@ -20,12 +20,12 @@ export class RedisLockService {
    * @returns A promise that resolves to true if the lock was acquired, otherwise false.
    */
   public async lockWithTimeOut(key: string, ttl: number): Promise<boolean> {
-    const lockValue = Date.now().toString();
     const result = await this.redisService.client.set(
       `${this.prefix}:${key}`,
-      lockValue,
+      Date.now().toString(),
       'PX',
       ttl,
+      'NX',
     );
     return result === 'OK';
   }
@@ -57,7 +57,10 @@ export class RedisLockService {
    * @param ttl - The TTL for the lock in milliseconds.
    * @returns A promise that resolves to true if the lock was acquired, otherwise false.
    */
-  private async acquireLock(key: string, ttl: number): Promise<boolean> {
+  private async acquireLock(
+    key: string,
+    ttl: number,
+  ): Promise<string | null> {
     const lockValue = Date.now().toString();
     const result = await this.redisService.client.set(
       `${this.prefix}:${key}`,
@@ -66,21 +69,31 @@ export class RedisLockService {
       ttl,
       'NX',
     );
-    return result === 'OK';
+    return result === 'OK' ? lockValue : null;
   }
 
   /**
-   * Releases the lock associated with the given key.
-   *
-   * This method deletes the lock entry from Redis, effectively releasing
-   * the lock. It ensures that the key is no longer marked as locked, allowing
-   * other operations to acquire the lock if necessary.
+   * Releases the lock associated with the given key using a Lua script
+   * that verifies ownership before deleting. This prevents a process from
+   * releasing another process's lock after the original TTL expired.
    *
    * @param key - The key for which the lock is to be released.
-   * @returns A promise that resolves once the lock has been released.
+   * @param lockValue - The value that was set when the lock was acquired (ownership proof).
+   * @returns A promise that resolves once the lock has been released (or skipped if not owner).
    */
-  private async releaseLock(key: string): Promise<void> {
-    await this.redisService.client.del(`${this.prefix}:${key}`);
+  private async releaseLock(key: string, lockValue: string): Promise<void> {
+    const script = `
+      if redis.call("GET", KEYS[1]) == ARGV[1] then
+        return redis.call("DEL", KEYS[1])
+      end
+      return 0
+    `;
+    await this.redisService.client.eval(
+      script,
+      1,
+      `${this.prefix}:${key}`,
+      lockValue,
+    );
   }
 
   /**
@@ -101,23 +114,21 @@ export class RedisLockService {
     ttl: number,
     action: () => Promise<T>,
   ): Promise<T | null> {
-    const acquired = await this.acquireLock(key, ttl);
+    const lockValue = await this.acquireLock(key, ttl);
 
-    if (!acquired) {
+    if (!lockValue) {
       this.logger.warn(`Failed to acquire lock for key: ${key}`);
       return null;
     }
 
     try {
       this.logger.debug(`Lock acquired for key: ${key}`);
-      const result = await action();
-      this.logger.debug(`Lock released for key: ${key}`);
-      return result;
+      return await action();
     } catch (error) {
       this.logger.error(`Error executing action for lock key: ${key}`, error);
       throw error;
     } finally {
-      await this.releaseLock(key);
+      await this.releaseLock(key, lockValue);
     }
   }
 }

--- a/core-api/src/services/services.module.ts
+++ b/core-api/src/services/services.module.ts
@@ -1,9 +1,10 @@
 import { HttpModule } from '@nestjs/axios';
 import { Global, Module } from '@nestjs/common';
 import { GeoIpService } from './geo-ip/geo-ip.service';
+import { RedisLockService } from './redis/distributed-lock.service';
 import { RedisService } from './redis/redis.service';
 
-const services = [RedisService, GeoIpService];
+const services = [RedisService, RedisLockService, GeoIpService];
 
 @Global()
 @Module({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daily statistics processing now runs with safer concurrency protection, reducing the risk of duplicate runs across multiple app instances.
* **Bug Fixes**
  * Statistics are now saved only when values actually change, helping reduce unnecessary updates.
  * Lock handling is more reliable, improving protection against overlapping background jobs and accidental lock conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->