### PR TITLE
feat(console): add worker selection to agent mode toggle

### DIFF
--- a/console/src/components/agent-prompt-input.tsx
+++ b/console/src/components/agent-prompt-input.tsx
@@ -23,6 +23,8 @@ interface AgentPromptInputProps {
   onSelectModel?: (provider: string, model: string, configId: string) => void;
   agentMode?: string;
   onAgentModeChange?: (mode: string) => void;
+  selectedWorkerId?: string | null;
+  onWorkerSelect?: (workerId: string | null) => void;
   placeholder?: string;
   className?: string;
 }
@@ -35,6 +37,8 @@ export default function AgentPromptInput({
   onSelectModel,
   agentMode = 'ask',
   onAgentModeChange,
+  selectedWorkerId,
+  onWorkerSelect,
   placeholder = 'Ask anything about security...',
   className,
 }: AgentPromptInputProps) {
@@ -73,6 +77,8 @@ export default function AgentPromptInput({
               <AgentModeSelect
                 value={agentMode}
                 onChange={onAgentModeChange}
+                selectedWorkerId={selectedWorkerId}
+                onWorkerChange={onWorkerSelect}
               />
             )}
             <PromptInputSubmit

--- a/console/src/components/ui/agent-mode-toggle.tsx
+++ b/console/src/components/ui/agent-mode-toggle.tsx
@@ -10,18 +10,22 @@ import {
   useAgentsControllerGetAgentModes,
 } from '@/services/apis/gen/queries';
 import { useConnectWorkerState } from '@/hooks/useConnectWorkerState';
-import { InfinityIcon, MonitorIcon } from 'lucide-react';
+import { CheckIcon, InfinityIcon, MonitorIcon } from 'lucide-react';
 import { memo } from 'react';
 import { toast } from 'sonner';
 
 interface AgentModeSelectProps {
   value: string;
   onChange: (mode: string) => void;
+  selectedWorkerId?: string | null;
+  onWorkerChange?: (workerId: string | null) => void;
 }
 
 export const AgentModeSelect = memo(function AgentModeSelect({
   value,
   onChange,
+  selectedWorkerId,
+  onWorkerChange,
 }: AgentModeSelectProps) {
   const isAgent = value === SendMessageDtoAgentMode.agent;
   const { data } = useAgentsControllerGetAgentModes();
@@ -41,7 +45,16 @@ export const AgentModeSelect = memo(function AgentModeSelect({
     if (next === SendMessageDtoAgentMode.agent) {
       toast.success('Agent mode enabled');
     }
+    if (next === SendMessageDtoAgentMode.ask) {
+      onWorkerChange?.(null);
+    }
     onChange(next);
+  };
+
+  const handleWorkerSelect = (workerId: string) => {
+    // Toggle selection: deselect if same worker is clicked again
+    const newId = selectedWorkerId === workerId ? null : workerId;
+    onWorkerChange?.(newId);
   };
 
   return (
@@ -58,27 +71,45 @@ export const AgentModeSelect = memo(function AgentModeSelect({
           </PromptInputActionMenuTrigger>
           <PromptInputActionMenuContent>
             {workers.length > 0 ? (
-              workers.map((worker) => (
+              <>
                 <PromptInputActionMenuItem
-                  key={worker.id}
-                  className="flex items-center gap-2"
+                  className="flex items-center gap-2 cursor-pointer"
+                  onClick={() => onWorkerChange?.(null)}
                 >
-                  {worker.os && (
-                    <img
-                      className="size-5 dark:brightness-0 dark:invert"
-                      src={`/${worker.os}.svg`}
-                      alt={worker.os}
-                    />
+                  <span className="flex-1 font-medium">Auto (any worker)</span>
+                  {!selectedWorkerId && (
+                    <CheckIcon className="size-4 text-green-500" />
                   )}
-                  <span className="flex-1">
-                    {worker.name ?? worker.id.slice(0, 8)}
-                  </span>
-                  <span className="relative flex h-2 w-2 shrink-0">
-                    <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-500 opacity-75" />
-                    <span className="relative inline-flex h-2 w-2 rounded-full bg-green-500" />
-                  </span>
                 </PromptInputActionMenuItem>
-              ))
+                {workers.map((worker) => {
+                  const isSelected = selectedWorkerId === worker.id;
+                  return (
+                    <PromptInputActionMenuItem
+                      key={worker.id}
+                      className="flex items-center gap-2 cursor-pointer"
+                      onClick={() => handleWorkerSelect(worker.id)}
+                    >
+                      {worker.os && (
+                        <img
+                          className="size-5 dark:brightness-0 dark:invert"
+                          src={`/${worker.os}.svg`}
+                          alt={worker.os}
+                        />
+                      )}
+                      <span className="flex-1">
+                        {worker.name ?? worker.id.slice(0, 8)}
+                      </span>
+                      <span className="relative flex h-2 w-2 shrink-0">
+                        <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-500 opacity-75" />
+                        <span className="relative inline-flex h-2 w-2 rounded-full bg-green-500" />
+                      </span>
+                      {isSelected && (
+                        <CheckIcon className="size-4 text-green-500 ml-1" />
+                      )}
+                    </PromptInputActionMenuItem>
+                  );
+                })}
+              </>
             ) : (
               <PromptInputActionMenuItem disabled>
                 No workers connected

--- a/console/src/hooks/use-agent-chat.ts
+++ b/console/src/hooks/use-agent-chat.ts
@@ -93,6 +93,7 @@ interface UseAgentChatReturn {
   todos: AgentTodoItem[];
   selectedModel: SelectedModel | null;
   agentMode: string;
+  selectedWorkerId: string | null;
   hasSentFirstMessage: boolean;
   hasMoreMessages: boolean;
   isLoadingMoreMessages: boolean;
@@ -104,6 +105,7 @@ interface UseAgentChatReturn {
   onDismissError: () => void;
   onLoadMore: (() => void) | undefined;
   onAgentModeChange: (mode: string) => void;
+  onWorkerSelect: (workerId: string | null) => void;
 }
 
 /**
@@ -238,6 +240,9 @@ export function useAgentChat({
   const selectedModelRef = useRef<SelectedModel | null>(selectedModel);
   const [agentMode, setAgentMode] = useState('ask');
   const agentModeRef = useRef('ask');
+  const [selectedWorkerId, setSelectedWorkerId] = useState<string | null>(
+    null,
+  );
 
   const {
     state: { selectedWorkspaceId },
@@ -311,11 +316,12 @@ export function useAgentChat({
                 provider: modelInfo.provider,
               }),
               agentMode: agentModeRef.current,
+              workerId: selectedWorkerId,
             },
           };
         },
       }),
-    [selectedWorkspaceId, conversationId],
+    [selectedWorkspaceId, conversationId, selectedWorkerId],
   );
 
   const {
@@ -588,6 +594,7 @@ export function useAgentChat({
       pendingMessage?: string;
       selectedModel?: SelectedModel;
       agentMode?: string;
+      workerId?: string | null;
     } | null;
     if (state?.pendingMessage && !hasAutoSentRef.current) {
       hasAutoSentRef.current = true;
@@ -598,6 +605,9 @@ export function useAgentChat({
       if (state.agentMode !== undefined) {
         setAgentMode(state.agentMode);
         agentModeRef.current = state.agentMode;
+      }
+      if (state.workerId !== undefined) {
+        setSelectedWorkerId(state.workerId);
       }
       void handleSendMessageRef.current(state.pendingMessage);
       void navigate({
@@ -620,6 +630,7 @@ export function useAgentChat({
     createdAt,
     selectedModel,
     agentMode,
+    selectedWorkerId,
     hasSentFirstMessage,
     hasMoreMessages: hasNextPage ?? false,
     isLoadingMoreMessages: isFetchingNextPage,
@@ -631,5 +642,6 @@ export function useAgentChat({
     onDismissError: handleDismissError,
     onLoadMore: onLoadMoreAction,
     onAgentModeChange: setAgentMode,
+    onWorkerSelect: setSelectedWorkerId,
   };
 }

--- a/console/src/pages/agents/agents-landing.tsx
+++ b/console/src/pages/agents/agents-landing.tsx
@@ -68,6 +68,9 @@ export default function AgentsLandingPage() {
     configId: string;
   } | null>(null);
   const [agentMode, setAgentMode] = useState('ask');
+  const [selectedWorkerId, setSelectedWorkerId] = useState<string | null>(
+    null,
+  );
 
   const {
     state: { selectedWorkspaceId },
@@ -124,6 +127,7 @@ export default function AgentsLandingPage() {
         pendingMessage: content.trim(),
         ...(selectedModel && { selectedModel }),
         agentMode: options?.agentMode ?? agentMode,
+        workerId: selectedWorkerId,
       };
       void navigate({
         to: '/agents/conversations/$conversationId',
@@ -131,7 +135,7 @@ export default function AgentsLandingPage() {
         state: navState,
       });
     },
-    [isSending, navigate, selectedModel, agentMode],
+    [isSending, navigate, selectedModel, agentMode, selectedWorkerId],
   );
 
   useEffect(() => {
@@ -205,6 +209,8 @@ export default function AgentsLandingPage() {
             }}
             agentMode={agentMode}
             onAgentModeChange={setAgentMode}
+            selectedWorkerId={selectedWorkerId}
+            onWorkerSelect={setSelectedWorkerId}
           />
 
           {/* Quick suggestions */}

--- a/console/src/pages/agents/agents.tsx
+++ b/console/src/pages/agents/agents.tsx
@@ -49,6 +49,7 @@ export default function AgentsChatPage() {
     createdAt,
     selectedModel,
     agentMode,
+    selectedWorkerId,
     hasSentFirstMessage,
     hasMoreMessages,
     isLoadingMoreMessages,
@@ -60,6 +61,7 @@ export default function AgentsChatPage() {
     onDismissError,
     onLoadMore,
     onAgentModeChange,
+    onWorkerSelect,
   } = useAgentChat({ conversationId });
 
   const [selectedToolCallId, setSelectedToolCallId] = useState<string | null>(
@@ -119,6 +121,8 @@ export default function AgentsChatPage() {
           isLoadingMoreMessages={isLoadingMoreMessages}
           agentMode={agentMode}
           onAgentModeChange={onAgentModeChange}
+          selectedWorkerId={selectedWorkerId}
+          onWorkerSelect={onWorkerSelect}
           todos={todos}
           showTodoAboveInput={!isLargeScreen}
           selectedToolCallId={selectedToolCallId}

--- a/console/src/pages/agents/chat-conversation.tsx
+++ b/console/src/pages/agents/chat-conversation.tsx
@@ -68,6 +68,8 @@ interface ChatConversationProps {
   isLoadingMoreMessages?: boolean;
   agentMode?: string;
   onAgentModeChange?: (mode: string) => void;
+  selectedWorkerId?: string | null;
+  onWorkerSelect?: (workerId: string | null) => void;
   todos?: AgentTodoItem[];
   showTodoAboveInput?: boolean;
   selectedToolCallId?: string | null;
@@ -586,6 +588,8 @@ export const ChatConversation = memo(function ChatConversation({
   isLoadingMoreMessages = false,
   agentMode = 'false',
   onAgentModeChange,
+  selectedWorkerId,
+  onWorkerSelect,
   todos,
   showTodoAboveInput = true,
   selectedToolCallId,
@@ -844,6 +848,8 @@ export const ChatConversation = memo(function ChatConversation({
             onSelectModel={onSelectModel}
             agentMode={agentMode}
             onAgentModeChange={onAgentModeChange}
+            selectedWorkerId={selectedWorkerId}
+            onWorkerSelect={onWorkerSelect}
             placeholder={
               isStreaming
                 ? 'Waiting for response…'

--- a/core-api/src/modules/agents/agents.completions.ts
+++ b/core-api/src/modules/agents/agents.completions.ts
@@ -487,6 +487,7 @@ export class AgentsCompletionsService {
         title: dto.question.slice(0, 500),
         createdBy: userId,
         agentMode: dto.agentMode,
+        workerId: dto.workerId,
       });
       return this.conversationRepository.save(newConversation);
     }
@@ -503,6 +504,7 @@ export class AgentsCompletionsService {
       title: dto.question.slice(0, 500),
       createdBy: userId,
       agentMode: dto.agentMode,
+      workerId: dto.workerId,
     });
     return this.conversationRepository.save(newConversation);
   }

--- a/core-api/src/modules/agents/agents.service.ts
+++ b/core-api/src/modules/agents/agents.service.ts
@@ -405,6 +405,7 @@ export class AgentsService {
       updatedAt: conversation.updatedAt,
       todos,
       summary: conversation.summary,
+      workerId: conversation.workerId,
     };
   }
 

--- a/core-api/src/modules/agents/dto/conversation.dto.ts
+++ b/core-api/src/modules/agents/dto/conversation.dto.ts
@@ -57,6 +57,15 @@ export class ConversationResponseDto {
   @IsOptional()
   @IsString()
   summary?: string;
+
+  @ApiProperty({
+    required: false,
+    description: 'The worker ID currently assigned to this conversation',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @IsOptional()
+  @IsUUID()
+  workerId?: string;
 }
 
 export class GetConversationsResponseDto {

--- a/core-api/src/modules/agents/dto/message.dto.ts
+++ b/core-api/src/modules/agents/dto/message.dto.ts
@@ -46,6 +46,16 @@ export class SendMessageDto {
   @IsOptional()
   @IsEnum(AgentMode)
   agentMode: AgentMode;
+
+  @ApiProperty({
+    required: false,
+    description:
+      'Preferred worker ID for remote command execution. Only respected when agentMode is "agent".',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @IsOptional()
+  @IsUUID()
+  workerId?: string;
 }
 
 export class ToolCallResponseDto {

--- a/core-api/src/modules/workers/remote-execute-subscribe.service.ts
+++ b/core-api/src/modules/workers/remote-execute-subscribe.service.ts
@@ -1,5 +1,6 @@
 import type { WrapperType } from '@/common/types/app.types';
 import { AgentConversation } from '@/modules/agents/entities/agent-conversation.entity';
+import { RedisService } from '@/services/redis/redis.service';
 import {
   forwardRef,
   Inject,
@@ -43,6 +44,7 @@ export class RemoteExecuteSubscribeService implements OnModuleDestroy {
     private readonly workersService: WrapperType<WorkersService>,
     @InjectRepository(AgentConversation)
     private readonly conversationRepo: Repository<AgentConversation>,
+    private readonly redisService: RedisService,
   ) {}
 
   registerWorker(worker: WorkerInstance): WorkerRegistration {
@@ -79,6 +81,63 @@ export class RemoteExecuteSubscribeService implements OnModuleDestroy {
   private isWorkerAlive(workerId: string): boolean {
     const subject = this.workers.get(workerId);
     return subject !== undefined && !subject.closed;
+  }
+
+  private static readonly CONV_WORKER_TTL = 86_400; // 1 day in seconds
+
+  /**
+   * Reads the cached worker ID for a conversation from Redis.
+   * Returns null if no cache entry exists or on error.
+   */
+  private async getCachedConversationWorker(
+    conversationId: string,
+  ): Promise<string | null> {
+    try {
+      return await this.redisService.get(
+        `agent:conv:worker:${conversationId}`,
+      );
+    } catch (err) {
+      this.logger.warn(
+        `[RedisCache] Failed to read cached worker for ${conversationId}: ${err}`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Writes the conversation-to-worker mapping to Redis with 1-day TTL.
+   * Fire-and-forget: non-blocking, failures are logged but do not block command push.
+   */
+  private async cacheConversationWorker(
+    conversationId: string,
+    workerId: string,
+  ): Promise<void> {
+    try {
+      await this.redisService.setex(
+        `agent:conv:worker:${conversationId}`,
+        RemoteExecuteSubscribeService.CONV_WORKER_TTL,
+        workerId,
+      );
+    } catch (err) {
+      this.logger.warn(
+        `[RedisCache] Failed to cache worker ${workerId} for conversation ${conversationId}: ${err}`,
+      );
+    }
+  }
+
+  /**
+   * Deletes the Redis cache entry for a conversation-to-worker mapping.
+   */
+  private async deleteCachedConversationWorker(
+    conversationId: string,
+  ): Promise<void> {
+    try {
+      await this.redisService.del(`agent:conv:worker:${conversationId}`);
+    } catch (err) {
+      this.logger.warn(
+        `[RedisCache] Failed to delete cached worker for conversation ${conversationId}: ${err}`,
+      );
+    }
   }
 
   private getNextAvailableWorker(): string | null {
@@ -157,6 +216,26 @@ export class RemoteExecuteSubscribeService implements OnModuleDestroy {
       return this.pushCommandWithSession(sessionId, command);
     }
 
+    // 1. Try Redis cache first (fast path)
+    const cachedWorkerId =
+      await this.getCachedConversationWorker(conversationId);
+
+    if (cachedWorkerId && this.isWorkerAlive(cachedWorkerId)) {
+      this.logger.verbose(
+        `[StickyWorker][Redis] Using cached worker ${cachedWorkerId} for conversation ${conversationId}`,
+      );
+      return this.pushCommand(cachedWorkerId, sessionId, command);
+    }
+
+    if (cachedWorkerId) {
+      // Cached worker is dead — clear stale cache
+      this.logger.warn(
+        `[StickyWorker][Redis] Cached worker ${cachedWorkerId} dead, clearing for conversation ${conversationId}`,
+      );
+      await this.deleteCachedConversationWorker(conversationId);
+    }
+
+    // 2. Try Postgres (existing sticky logic)
     const conversation = await this.conversationRepo.findOne({
       where: { id: conversationId },
       select: ['id', 'workerId'],
@@ -164,15 +243,14 @@ export class RemoteExecuteSubscribeService implements OnModuleDestroy {
 
     if (conversation?.workerId && this.isWorkerAlive(conversation.workerId)) {
       this.logger.verbose(
-        `[StickyWorker] Using pinned worker ${conversation.workerId} for conversation ${conversationId}`,
+        `[StickyWorker][DB] Using pinned worker ${conversation.workerId} for conversation ${conversationId}`,
       );
-      return this.pushCommand(
-        conversation.workerId,
-        sessionId,
-        command,
-      );
+      // Warm the Redis cache
+      void this.cacheConversationWorker(conversationId, conversation.workerId);
+      return this.pushCommand(conversation.workerId, sessionId, command);
     }
 
+    // 3. Fallback to any available worker
     const workerId = this.getNextAvailableWorker();
     if (!workerId) {
       return null;
@@ -188,6 +266,7 @@ export class RemoteExecuteSubscribeService implements OnModuleDestroy {
       return null;
     }
 
+    // Persist assignment to both Postgres and Redis
     if (conversation) {
       await this.conversationRepo
         .createQueryBuilder()
@@ -198,6 +277,9 @@ export class RemoteExecuteSubscribeService implements OnModuleDestroy {
           workerId,
         })
         .execute();
+
+      // Write to Redis cache (fire-and-forget)
+      void this.cacheConversationWorker(conversationId, workerId);
     }
 
     this.logger.log(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent chats can now be tied to a specific worker, with an “auto” option to let any available worker handle the message.
  * Worker selection is preserved when starting or continuing a conversation.

* **Bug Fixes**
  * Conversations now return the selected worker in their details.
  * Message sending now includes the chosen worker, helping keep chat routing consistent across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->