### PR TITLE
refactor(core-api): convert entity enum columns to varchar type

### DIFF
--- a/core-api/src/database/migrations/1784014752144-ConvertEnumColumnsToString.ts
+++ b/core-api/src/database/migrations/1784014752144-ConvertEnumColumnsToString.ts
@@ -1,0 +1,335 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class ConvertEnumColumnsToString1784014752144 implements MigrationInterface {
+    name = 'ConvertEnumColumnsToString1784014752144'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Use ALTER COLUMN TYPE instead of DROP/ADD to preserve existing data
+        // and avoid NOT NULL constraint failures on existing rows.
+        // The USING clause casts the enum label to text, then to varchar.
+
+        // api_keys.type
+        await queryRunner.query(`ALTER TABLE "api_keys" ALTER COLUMN "type" TYPE varchar USING "type"::text::varchar`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."api_keys_type_enum"`);
+
+        // vulnerability_dismissals.reason
+        await queryRunner.query(`ALTER TABLE "vulnerability_dismissals" ALTER COLUMN "reason" TYPE varchar USING "reason"::text::varchar`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."vulnerability_dismissals_reason_enum"`);
+
+        // vulnerabilities.severity
+        await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_vuln_severity_isArchived"`);
+        await queryRunner.query(`ALTER TABLE "vulnerabilities" ALTER COLUMN "severity" TYPE varchar USING "severity"::text::varchar`);
+        await queryRunner.query(`ALTER TABLE "vulnerabilities" ALTER COLUMN "severity" SET DEFAULT 'info'`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."vulnerabilities_severity_enum"`);
+
+        // vulnerabilities.analyzeStatus
+        await queryRunner.query(`ALTER TABLE "vulnerabilities" ALTER COLUMN "analyzeStatus" TYPE varchar USING "analyzeStatus"::text::varchar`);
+        await queryRunner.query(`ALTER TABLE "vulnerabilities" ALTER COLUMN "analyzeStatus" SET DEFAULT 'not_analyzed'`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."vulnerabilities_analyzestatus_enum"`);
+
+        // workers.type
+        await queryRunner.query(`ALTER TABLE "workers" ALTER COLUMN "type" TYPE varchar USING "type"::text::varchar`);
+        await queryRunner.query(`ALTER TABLE "workers" ALTER COLUMN "type" SET DEFAULT 'built_in'`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."workers_type_enum"`);
+
+        // workers.scope
+        await queryRunner.query(`ALTER TABLE "workers" ALTER COLUMN "scope" TYPE varchar USING "scope"::text::varchar`);
+        await queryRunner.query(`ALTER TABLE "workers" ALTER COLUMN "scope" SET DEFAULT 'workspace'`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."workers_scope_enum"`);
+
+        // tools.category
+        await queryRunner.query(`ALTER TABLE "tools" ALTER COLUMN "category" TYPE varchar USING "category"::text::varchar`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."tools_category_enum"`);
+
+        // tools.type
+        await queryRunner.query(`ALTER TABLE "tools" ALTER COLUMN "type" TYPE varchar USING "type"::text::varchar`);
+        await queryRunner.query(`ALTER TABLE "tools" ALTER COLUMN "type" SET DEFAULT 'built_in'`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."tools_type_enum"`);
+
+        // tools.priority
+        await queryRunner.query(`ALTER TABLE "tools" ALTER COLUMN "priority" TYPE varchar USING "priority"::text::varchar`);
+        await queryRunner.query(`ALTER TABLE "tools" ALTER COLUMN "priority" SET DEFAULT '4'`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."tools_priority_enum"`);
+
+        // jobs.category
+        await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_jobs_category_status"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_jobs_workerId_status"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_jobs_asset_status"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_jobs_status_priority_createdAt"`);
+        await queryRunner.query(`ALTER TABLE "jobs" ALTER COLUMN "category" TYPE varchar USING "category"::text::varchar`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."jobs_category_enum"`);
+
+        // jobs.status
+        await queryRunner.query(`ALTER TABLE "jobs" ALTER COLUMN "status" TYPE varchar USING "status"::text::varchar`);
+        await queryRunner.query(`ALTER TABLE "jobs" ALTER COLUMN "status" SET DEFAULT 'pending'`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."jobs_status_enum"`);
+
+        // jobs.priority
+        await queryRunner.query(`ALTER TABLE "jobs" ALTER COLUMN "priority" TYPE varchar USING "priority"::text::varchar`);
+        await queryRunner.query(`ALTER TABLE "jobs" ALTER COLUMN "priority" SET DEFAULT '4'`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."jobs_priority_enum"`);
+
+        // job_histories.jobRunType
+        await queryRunner.query(`ALTER TABLE "job_histories" ALTER COLUMN "jobRunType" TYPE varchar USING "jobRunType"::text::varchar`);
+        await queryRunner.query(`ALTER TABLE "job_histories" ALTER COLUMN "jobRunType" SET DEFAULT 'manual'`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."job_histories_jobruntype_enum"`);
+
+        // asset_group_workflows.schedule
+        await queryRunner.query(`ALTER TABLE "asset_group_workflows" ALTER COLUMN "schedule" TYPE varchar USING "schedule"::text::varchar`);
+        await queryRunner.query(`ALTER TABLE "asset_group_workflows" ALTER COLUMN "schedule" SET DEFAULT 'disabled'`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."asset_group_workflows_schedule_enum"`);
+
+        // targets.type
+        await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_targets_scanSchedule_jobId"`);
+        await queryRunner.query(`ALTER TABLE "targets" ALTER COLUMN "type" TYPE varchar USING "type"::text::varchar`);
+        await queryRunner.query(`ALTER TABLE "targets" ALTER COLUMN "type" SET DEFAULT 'DOMAIN'`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."targets_type_enum"`);
+
+        // targets.scanSchedule
+        await queryRunner.query(`ALTER TABLE "targets" ALTER COLUMN "scanSchedule" TYPE varchar USING "scanSchedule"::text::varchar`);
+        await queryRunner.query(`ALTER TABLE "targets" ALTER COLUMN "scanSchedule" SET DEFAULT 'disabled'`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."targets_scanschedule_enum"`);
+
+        // workspace_members.role
+        await queryRunner.query(`ALTER TABLE "workspace_members" ALTER COLUMN "role" TYPE varchar USING "role"::text::varchar`);
+        await queryRunner.query(`ALTER TABLE "workspace_members" ALTER COLUMN "role" SET DEFAULT 'owner'`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."workspace_members_role_enum"`);
+
+        // users.role
+        await queryRunner.query(`ALTER TABLE "users" ALTER COLUMN "role" TYPE varchar USING "role"::text::varchar`);
+        await queryRunner.query(`ALTER TABLE "users" ALTER COLUMN "role" SET DEFAULT 'user'`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."users_role_enum"`);
+
+        // reports.type
+        await queryRunner.query(`ALTER TABLE "reports" ALTER COLUMN "type" TYPE varchar USING "type"::text::varchar`);
+        await queryRunner.query(`ALTER TABLE "reports" ALTER COLUMN "type" SET DEFAULT 'SUMMARY'`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."reports_type_enum"`);
+
+        // notifications.scope
+        await queryRunner.query(`ALTER TABLE "notifications" ALTER COLUMN "scope" TYPE varchar USING "scope"::text::varchar`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."notifications_scope_enum"`);
+
+        // notifications.type
+        await queryRunner.query(`ALTER TABLE "notifications" ALTER COLUMN "type" TYPE varchar USING "type"::text::varchar`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."notifications_type_enum"`);
+
+        // notification_recipients.status
+        await queryRunner.query(`ALTER TABLE "notification_recipients" ALTER COLUMN "status" TYPE varchar USING "status"::text::varchar`);
+        await queryRunner.query(`ALTER TABLE "notification_recipients" ALTER COLUMN "status" SET DEFAULT 'sent'`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."notification_recipients_status_enum"`);
+
+        // issues.status
+        await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_issues_workspaceId_status"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_issues_sourceType_sourceId_workspaceId_open"`);
+        await queryRunner.query(`ALTER TABLE "issues" ALTER COLUMN "status" TYPE varchar USING "status"::text::varchar`);
+        await queryRunner.query(`ALTER TABLE "issues" ALTER COLUMN "status" SET DEFAULT 'open'`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."issues_status_enum"`);
+
+        // issues.sourceType
+        await queryRunner.query(`ALTER TABLE "issues" ALTER COLUMN "sourceType" TYPE varchar USING "sourceType"::text::varchar`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."issues_sourcetype_enum"`);
+
+        // issue_comments.type
+        await queryRunner.query(`ALTER TABLE "issue_comments" ALTER COLUMN "type" TYPE varchar USING "type"::text::varchar`);
+        await queryRunner.query(`ALTER TABLE "issue_comments" ALTER COLUMN "type" SET DEFAULT 'content'`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."issue_comments_type_enum"`);
+
+        // agent_messages.role
+        await queryRunner.query(`ALTER TABLE "agent_messages" ALTER COLUMN "role" TYPE varchar USING "role"::text::varchar`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."agent_messages_role_enum"`);
+
+        // agent_messages.messageType
+        await queryRunner.query(`ALTER TABLE "agent_messages" ALTER COLUMN "messageType" TYPE varchar USING "messageType"::text::varchar`);
+        await queryRunner.query(`ALTER TABLE "agent_messages" ALTER COLUMN "messageType" SET DEFAULT 'text'`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."agent_messages_messagetype_enum"`);
+
+        // agent_conversations.agentMode
+        await queryRunner.query(`ALTER TABLE "agent_conversations" ALTER COLUMN "agentMode" TYPE varchar USING "agentMode"::text::varchar`);
+        await queryRunner.query(`ALTER TABLE "agent_conversations" ALTER COLUMN "agentMode" SET DEFAULT 'ask'`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."agent_conversations_agentmode_enum"`);
+
+        // agent_llm_configs.provider
+        await queryRunner.query(`ALTER TABLE "agent_llm_configs" ALTER COLUMN "provider" TYPE varchar USING "provider"::text::varchar`);
+        await queryRunner.query(`DROP TYPE IF EXISTS "public"."agent_llm_configs_provider_enum"`);
+
+        // agent_mcp_configs.configJson default (unrelated but part of schema sync)
+        await queryRunner.query(`ALTER TABLE "agent_mcp_configs" ALTER COLUMN "configJson" SET DEFAULT '{"mcpServers":{}}'`);
+
+        // Re-create indexes that were dropped for enum-dependent partial indexes
+        await queryRunner.query(`CREATE INDEX "IDX_vuln_severity_isArchived" ON "vulnerabilities" ("severity", "isArchived") `);
+        await queryRunner.query(`CREATE INDEX "IDX_jobs_category_status" ON "jobs" ("category", "status") `);
+        await queryRunner.query(`CREATE INDEX "IDX_jobs_workerId_status" ON "jobs" ("workerId", "status") `);
+        await queryRunner.query(`CREATE INDEX "IDX_jobs_asset_status" ON "jobs" ("assetId", "status") `);
+        await queryRunner.query(`CREATE INDEX "IDX_jobs_status_priority_createdAt" ON "jobs" ("status", "priority", "createdAt") `);
+        await queryRunner.query(`CREATE INDEX "IDX_targets_scanSchedule_jobId" ON "targets" ("scanSchedule", "jobId") `);
+        await queryRunner.query(`CREATE INDEX "IDX_issues_sourceType_sourceId_workspaceId_open" ON "issues" ("sourceType", "sourceId", "workspaceId") WHERE status = 'open' AND "sourceType" IS NOT NULL AND "sourceId" IS NOT NULL`);
+        await queryRunner.query(`CREATE INDEX "IDX_issues_workspaceId_status" ON "issues" ("workspaceId", "status") `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_issues_workspaceId_status"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_issues_sourceType_sourceId_workspaceId_open"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_targets_scanSchedule_jobId"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_jobs_status_priority_createdAt"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_jobs_asset_status"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_jobs_workerId_status"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_jobs_category_status"`);
+        await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_vuln_severity_isArchived"`);
+
+        // agent_mcp_configs
+        await queryRunner.query(`ALTER TABLE "agent_mcp_configs" ALTER COLUMN "configJson" SET DEFAULT '{"mcpServers": {}}'`);
+
+        // agent_llm_configs.provider
+        await queryRunner.query(`ALTER TABLE "agent_llm_configs" DROP COLUMN "provider"`);
+        await queryRunner.query(`CREATE TYPE "public"."agent_llm_configs_provider_enum" AS ENUM('openai', 'openrouter', 'gemini', 'anthropic', 'kilo_code', 'custom')`);
+        await queryRunner.query(`ALTER TABLE "agent_llm_configs" ADD "provider" "public"."agent_llm_configs_provider_enum" NOT NULL`);
+
+        // agent_conversations.agentMode
+        await queryRunner.query(`ALTER TABLE "agent_conversations" DROP COLUMN "agentMode"`);
+        await queryRunner.query(`CREATE TYPE "public"."agent_conversations_agentmode_enum" AS ENUM('ask', 'agent')`);
+        await queryRunner.query(`ALTER TABLE "agent_conversations" ADD "agentMode" "public"."agent_conversations_agentmode_enum" NOT NULL DEFAULT 'ask'`);
+
+        // agent_messages.messageType
+        await queryRunner.query(`ALTER TABLE "agent_messages" DROP COLUMN "messageType"`);
+        await queryRunner.query(`CREATE TYPE "public"."agent_messages_messagetype_enum" AS ENUM('text', 'thinking', 'error')`);
+        await queryRunner.query(`ALTER TABLE "agent_messages" ADD "messageType" "public"."agent_messages_messagetype_enum" NOT NULL DEFAULT 'text'`);
+
+        // agent_messages.role
+        await queryRunner.query(`ALTER TABLE "agent_messages" DROP COLUMN "role"`);
+        await queryRunner.query(`CREATE TYPE "public"."agent_messages_role_enum" AS ENUM('user', 'assistant', 'system')`);
+        await queryRunner.query(`ALTER TABLE "agent_messages" ADD "role" "public"."agent_messages_role_enum" NOT NULL`);
+
+        // issue_comments.type
+        await queryRunner.query(`ALTER TABLE "issue_comments" DROP COLUMN "type"`);
+        await queryRunner.query(`CREATE TYPE "public"."issue_comments_type_enum" AS ENUM('content', 'open', 'closed')`);
+        await queryRunner.query(`ALTER TABLE "issue_comments" ADD "type" "public"."issue_comments_type_enum" NOT NULL DEFAULT 'content'`);
+
+        // issues.sourceType
+        await queryRunner.query(`ALTER TABLE "issues" DROP COLUMN "sourceType"`);
+        await queryRunner.query(`CREATE TYPE "public"."issues_sourcetype_enum" AS ENUM('vulnerability')`);
+        await queryRunner.query(`ALTER TABLE "issues" ADD "sourceType" "public"."issues_sourcetype_enum"`);
+
+        // issues.status
+        await queryRunner.query(`ALTER TABLE "issues" DROP COLUMN "status"`);
+        await queryRunner.query(`CREATE TYPE "public"."issues_status_enum" AS ENUM('open', 'closed')`);
+        await queryRunner.query(`ALTER TABLE "issues" ADD "status" "public"."issues_status_enum" NOT NULL DEFAULT 'open'`);
+        await queryRunner.query(`CREATE INDEX "IDX_issues_sourceType_sourceId_workspaceId_open" ON "issues" ("sourceId", "sourceType", "workspaceId") WHERE ((status = 'open'::issues_status_enum) AND ("sourceType" IS NOT NULL) AND ("sourceId" IS NOT NULL))`);
+        await queryRunner.query(`CREATE INDEX "IDX_issues_workspaceId_status" ON "issues" ("status", "workspaceId") `);
+
+        // notification_recipients.status
+        await queryRunner.query(`ALTER TABLE "notification_recipients" DROP COLUMN "status"`);
+        await queryRunner.query(`CREATE TYPE "public"."notification_recipients_status_enum" AS ENUM('sent', 'unread', 'read')`);
+        await queryRunner.query(`ALTER TABLE "notification_recipients" ADD "status" "public"."notification_recipients_status_enum" NOT NULL DEFAULT 'sent'`);
+
+        // notifications.type
+        await queryRunner.query(`ALTER TABLE "notifications" DROP COLUMN "type"`);
+        await queryRunner.query(`CREATE TYPE "public"."notifications_type_enum" AS ENUM('WORKSPACE_CREATED', 'VULNERABILITY_ANALYSIS_COMPLETED', 'ASSET_NEW_DETECT')`);
+        await queryRunner.query(`ALTER TABLE "notifications" ADD "type" "public"."notifications_type_enum" NOT NULL`);
+
+        // notifications.scope
+        await queryRunner.query(`ALTER TABLE "notifications" DROP COLUMN "scope"`);
+        await queryRunner.query(`CREATE TYPE "public"."notifications_scope_enum" AS ENUM('SYSTEM', 'USER', 'GROUP')`);
+        await queryRunner.query(`ALTER TABLE "notifications" ADD "scope" "public"."notifications_scope_enum" NOT NULL`);
+
+        // reports.type
+        await queryRunner.query(`ALTER TABLE "reports" DROP COLUMN "type"`);
+        await queryRunner.query(`CREATE TYPE "public"."reports_type_enum" AS ENUM('SUMMARY', 'VULNERABILITY')`);
+        await queryRunner.query(`ALTER TABLE "reports" ADD "type" "public"."reports_type_enum" NOT NULL DEFAULT 'SUMMARY'`);
+
+        // users.role
+        await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "role"`);
+        await queryRunner.query(`CREATE TYPE "public"."users_role_enum" AS ENUM('admin', 'user', 'bot')`);
+        await queryRunner.query(`ALTER TABLE "users" ADD "role" "public"."users_role_enum" NOT NULL DEFAULT 'user'`);
+
+        // workspace_members.role
+        await queryRunner.query(`ALTER TABLE "workspace_members" DROP COLUMN "role"`);
+        await queryRunner.query(`CREATE TYPE "public"."workspace_members_role_enum" AS ENUM('owner', 'member')`);
+        await queryRunner.query(`ALTER TABLE "workspace_members" ADD "role" "public"."workspace_members_role_enum" NOT NULL DEFAULT 'owner'`);
+
+        // targets.scanSchedule
+        await queryRunner.query(`ALTER TABLE "targets" DROP COLUMN "scanSchedule"`);
+        await queryRunner.query(`CREATE TYPE "public"."targets_scanschedule_enum" AS ENUM('disabled', '0 0 * * *', '0 0 */3 * *', '0 0 * * 0', '0 0 */14 * *', '0 0 1 * *')`);
+        await queryRunner.query(`ALTER TABLE "targets" ADD "scanSchedule" "public"."targets_scanschedule_enum" DEFAULT 'disabled'`);
+
+        // targets.type
+        await queryRunner.query(`ALTER TABLE "targets" DROP COLUMN "type"`);
+        await queryRunner.query(`CREATE TYPE "public"."targets_type_enum" AS ENUM('DOMAIN', 'CIDR', 'IP')`);
+        await queryRunner.query(`ALTER TABLE "targets" ADD "type" "public"."targets_type_enum" NOT NULL DEFAULT 'DOMAIN'`);
+        await queryRunner.query(`CREATE INDEX "IDX_targets_scanSchedule_jobId" ON "targets" ("jobId", "scanSchedule") `);
+
+        // asset_group_workflows.schedule
+        await queryRunner.query(`ALTER TABLE "asset_group_workflows" DROP COLUMN "schedule"`);
+        await queryRunner.query(`CREATE TYPE "public"."asset_group_workflows_schedule_enum" AS ENUM('disabled', '0 0 * * *', '0 0 */3 * *', '0 0 * * 0', '0 0 */14 * *', '0 0 1 * *')`);
+        await queryRunner.query(`ALTER TABLE "asset_group_workflows" ADD "schedule" "public"."asset_group_workflows_schedule_enum" NOT NULL DEFAULT 'disabled'`);
+
+        // job_histories.jobRunType
+        await queryRunner.query(`ALTER TABLE "job_histories" DROP COLUMN "jobRunType"`);
+        await queryRunner.query(`CREATE TYPE "public"."job_histories_jobruntype_enum" AS ENUM('manual', 'scheduled')`);
+        await queryRunner.query(`ALTER TABLE "job_histories" ADD "jobRunType" "public"."job_histories_jobruntype_enum" NOT NULL DEFAULT 'manual'`);
+
+        // jobs.priority
+        await queryRunner.query(`ALTER TABLE "jobs" DROP COLUMN "priority"`);
+        await queryRunner.query(`CREATE TYPE "public"."jobs_priority_enum" AS ENUM('0', '1', '2', '3', '4')`);
+        await queryRunner.query(`ALTER TABLE "jobs" ADD "priority" "public"."jobs_priority_enum" NOT NULL DEFAULT '4'`);
+
+        // jobs.status
+        await queryRunner.query(`ALTER TABLE "jobs" DROP COLUMN "status"`);
+        await queryRunner.query(`CREATE TYPE "public"."jobs_status_enum" AS ENUM('pending', 'in_progress', 'completed', 'failed', 'cancelled')`);
+        await queryRunner.query(`ALTER TABLE "jobs" ADD "status" "public"."jobs_status_enum" NOT NULL DEFAULT 'pending'`);
+
+        // jobs.category
+        await queryRunner.query(`ALTER TABLE "jobs" DROP COLUMN "category"`);
+        await queryRunner.query(`CREATE TYPE "public"."jobs_category_enum" AS ENUM('subdomains', 'http_probe', 'ports_scanner', 'vulnerabilities', 'screenshot', 'classifier', 'assistant')`);
+        await queryRunner.query(`ALTER TABLE "jobs" ADD "category" "public"."jobs_category_enum" NOT NULL`);
+        await queryRunner.query(`CREATE INDEX "IDX_jobs_status_priority_createdAt" ON "jobs" ("createdAt", "priority", "status") `);
+        await queryRunner.query(`CREATE INDEX "IDX_jobs_asset_status" ON "jobs" ("assetId", "status") `);
+        await queryRunner.query(`CREATE INDEX "IDX_jobs_workerId_status" ON "jobs" ("status", "workerId") `);
+        await queryRunner.query(`CREATE INDEX "IDX_jobs_category_status" ON "jobs" ("category", "status") `);
+
+        // tools.priority
+        await queryRunner.query(`ALTER TABLE "tools" DROP COLUMN "priority"`);
+        await queryRunner.query(`CREATE TYPE "public"."tools_priority_enum" AS ENUM('0', '1', '2', '3', '4')`);
+        await queryRunner.query(`ALTER TABLE "tools" ADD "priority" "public"."tools_priority_enum" NOT NULL DEFAULT '4'`);
+
+        // tools.type
+        await queryRunner.query(`ALTER TABLE "tools" DROP COLUMN "type"`);
+        await queryRunner.query(`CREATE TYPE "public"."tools_type_enum" AS ENUM('built_in', 'provider')`);
+        await queryRunner.query(`ALTER TABLE "tools" ADD "type" "public"."tools_type_enum" NOT NULL DEFAULT 'built_in'`);
+
+        // tools.category
+        await queryRunner.query(`ALTER TABLE "tools" DROP COLUMN "category"`);
+        await queryRunner.query(`CREATE TYPE "public"."tools_category_enum" AS ENUM('subdomains', 'http_probe', 'ports_scanner', 'vulnerabilities', 'screenshot', 'classifier', 'assistant')`);
+        await queryRunner.query(`ALTER TABLE "tools" ADD "category" "public"."tools_category_enum" NOT NULL`);
+
+        // workers.scope
+        await queryRunner.query(`ALTER TABLE "workers" DROP COLUMN "scope"`);
+        await queryRunner.query(`CREATE TYPE "public"."workers_scope_enum" AS ENUM('cloud', 'workspace')`);
+        await queryRunner.query(`ALTER TABLE "workers" ADD "scope" "public"."workers_scope_enum" NOT NULL DEFAULT 'workspace'`);
+
+        // workers.type
+        await queryRunner.query(`ALTER TABLE "workers" DROP COLUMN "type"`);
+        await queryRunner.query(`CREATE TYPE "public"."workers_type_enum" AS ENUM('built_in', 'provider')`);
+        await queryRunner.query(`ALTER TABLE "workers" ADD "type" "public"."workers_type_enum" NOT NULL DEFAULT 'built_in'`);
+
+        // vulnerabilities.analyzeStatus
+        await queryRunner.query(`ALTER TABLE "vulnerabilities" DROP COLUMN "analyzeStatus"`);
+        await queryRunner.query(`CREATE TYPE "public"."vulnerabilities_analyzestatus_enum" AS ENUM('not_analyzed', 'running', 'done', 'failed')`);
+        await queryRunner.query(`ALTER TABLE "vulnerabilities" ADD "analyzeStatus" "public"."vulnerabilities_analyzestatus_enum" NOT NULL DEFAULT 'not_analyzed'`);
+
+        // vulnerabilities.severity
+        await queryRunner.query(`ALTER TABLE "vulnerabilities" DROP COLUMN "severity"`);
+        await queryRunner.query(`CREATE TYPE "public"."vulnerabilities_severity_enum" AS ENUM('info', 'low', 'medium', 'high', 'critical')`);
+        await queryRunner.query(`ALTER TABLE "vulnerabilities" ADD "severity" "public"."vulnerabilities_severity_enum" NOT NULL DEFAULT 'info'`);
+        await queryRunner.query(`CREATE INDEX "IDX_vuln_severity_isArchived" ON "vulnerabilities" ("isArchived", "severity") `);
+
+        // vulnerability_dismissals.reason
+        await queryRunner.query(`ALTER TABLE "vulnerability_dismissals" DROP COLUMN "reason"`);
+        await queryRunner.query(`CREATE TYPE "public"."vulnerability_dismissals_reason_enum" AS ENUM('false_positive', 'used_in_test', 'wont_fix')`);
+        await queryRunner.query(`ALTER TABLE "vulnerability_dismissals" ADD "reason" "public"."vulnerability_dismissals_reason_enum" NOT NULL`);
+
+        // api_keys.type
+        await queryRunner.query(`ALTER TABLE "api_keys" DROP COLUMN "type"`);
+        await queryRunner.query(`CREATE TYPE "public"."api_keys_type_enum" AS ENUM('tool', 'workspace', 'mcp')`);
+        await queryRunner.query(`ALTER TABLE "api_keys" ADD "type" "public"."api_keys_type_enum" NOT NULL`);
+    }
+}

--- a/core-api/src/modules/agents/entities/agent-conversation.entity.ts
+++ b/core-api/src/modules/agents/entities/agent-conversation.entity.ts
@@ -59,7 +59,7 @@ export class AgentConversation {
 
   @ApiProperty({ example: AgentMode.ASK })
   @IsEnum(AgentMode)
-  @Column({ type: 'enum', enum: AgentMode, default: AgentMode.ASK })
+  @Column({ type: 'varchar', default: AgentMode.ASK })
   agentMode: AgentMode;
 
   @ApiProperty({

--- a/core-api/src/modules/agents/entities/agent-llm-config.entity.ts
+++ b/core-api/src/modules/agents/entities/agent-llm-config.entity.ts
@@ -33,7 +33,7 @@ export class AgentLLMConfig extends BaseEntity {
 
   @ApiProperty({ enum: LLMProvider, example: LLMProvider.OPENAI })
   @IsEnum(LLMProvider)
-  @Column({ type: 'enum', enum: LLMProvider })
+  @Column({ type: 'varchar' })
   provider: LLMProvider;
 
   @Column('text')

--- a/core-api/src/modules/agents/entities/agent-message.entity.ts
+++ b/core-api/src/modules/agents/entities/agent-message.entity.ts
@@ -23,7 +23,7 @@ export class AgentMessage extends BaseEntity {
 
   @ApiProperty({ enum: MessageRole, example: MessageRole.USER })
   @IsEnum(MessageRole)
-  @Column({ type: 'enum', enum: MessageRole })
+  @Column({ type: 'varchar' })
   role: MessageRole;
 
   @ApiProperty({ example: 'Hello, how can you help me?' })
@@ -37,7 +37,7 @@ export class AgentMessage extends BaseEntity {
     default: MessageType.TEXT,
   })
   @IsEnum(MessageType)
-  @Column({ type: 'enum', enum: MessageType, default: MessageType.TEXT })
+  @Column({ type: 'varchar', default: MessageType.TEXT })
   messageType: MessageType;
 
   @ApiProperty({

--- a/core-api/src/modules/apikeys/entities/apikey.entity.ts
+++ b/core-api/src/modules/apikeys/entities/apikey.entity.ts
@@ -15,7 +15,7 @@ export class ApiKey extends BaseEntity {
   key: string;
 
   @ApiProperty({ enum: ApiKeyType })
-  @Column({ type: 'enum', enum: ApiKeyType })
+  @Column({ type: 'varchar' })
   type: ApiKeyType;
 
   @Column({ nullable: true })

--- a/core-api/src/modules/asset-group/entities/asset-groups-workflows.entity.ts
+++ b/core-api/src/modules/asset-group/entities/asset-groups-workflows.entity.ts
@@ -25,7 +25,7 @@ export class AssetGroupWorkflow extends BaseEntity {
   workflow: Relation<Workflow>;
 
   @ApiProperty({ enum: CronSchedule })
-  @Column({ type: 'enum', enum: CronSchedule, default: CronSchedule.DISABLED })
+  @Column({ type: 'varchar', default: CronSchedule.DISABLED })
   @IsEnum(CronSchedule)
   schedule: CronSchedule;
 

--- a/core-api/src/modules/auth/entities/user.entity.ts
+++ b/core-api/src/modules/auth/entities/user.entity.ts
@@ -28,7 +28,7 @@ export class User extends BaseEntity {
   image?: string;
 
   @ApiProperty({ enum: Role })
-  @Column({ type: 'enum', enum: Role, default: Role.USER })
+  @Column({ type: 'varchar', default: Role.USER })
   role: Role;
 
   @Column({ type: 'text', default: 'en' })

--- a/core-api/src/modules/issues/entities/issue-comment.entity.ts
+++ b/core-api/src/modules/issues/entities/issue-comment.entity.ts
@@ -49,7 +49,7 @@ export class IssueComment extends BaseEntity {
     enum: IssueCommentType,
     default: IssueCommentType.CONTENT,
   })
-  @Column({ type: 'enum', enum: IssueCommentType, default: IssueCommentType.CONTENT })
+  @Column({ type: 'varchar', default: IssueCommentType.CONTENT })
   type: IssueCommentType;
 
   @ApiProperty({ required: false })

--- a/core-api/src/modules/issues/entities/issue.entity.ts
+++ b/core-api/src/modules/issues/entities/issue.entity.ts
@@ -24,16 +24,14 @@ export class Issue extends BaseEntity {
 
   @ApiProperty()
   @Column({
-    type: 'enum',
-    enum: IssueStatus,
+    type: 'varchar',
     default: IssueStatus.OPEN,
   })
   status: IssueStatus;
 
   @ApiProperty()
   @Column({
-    type: 'enum',
-    enum: IssueSourceType,
+    type: 'varchar',
     nullable: true,
   })
   sourceType: IssueSourceType;

--- a/core-api/src/modules/jobs-registry/entities/job-history.entity.ts
+++ b/core-api/src/modules/jobs-registry/entities/job-history.entity.ts
@@ -50,8 +50,7 @@ export class JobHistory extends BaseEntity {
   jobHistoryName?: string;
 
   @Column({
-    type: 'enum',
-    enum: JobRunType,
+    type: 'varchar',
     default: JobRunType.MANUAL,
   })
   jobRunType: JobRunType;

--- a/core-api/src/modules/jobs-registry/entities/job.entity.ts
+++ b/core-api/src/modules/jobs-registry/entities/job.entity.ts
@@ -30,14 +30,14 @@ export class Job extends BaseEntity {
    * The category of the tool used in the job.
    */
   @ApiProperty()
-  @Column({ type: 'enum', enum: ToolCategory })
+  @Column({ type: 'varchar' })
   category: ToolCategory;
 
   /**
    * The current status of the job.
    */
   @ApiProperty()
-  @Column({ type: 'enum', enum: JobStatus, default: JobStatus.PENDING })
+  @Column({ type: 'varchar', default: JobStatus.PENDING })
   status?: JobStatus;
 
   /**
@@ -50,7 +50,7 @@ export class Job extends BaseEntity {
   /**
    * The priority of the job.
    */
-  @Column({ type: 'enum', enum: JobPriority, default: JobPriority.BACKGROUND })
+  @Column({ type: 'varchar', default: JobPriority.BACKGROUND })
   priority?: JobPriority;
 
   /**

--- a/core-api/src/modules/notifications/entities/notification-recipient.entity.ts
+++ b/core-api/src/modules/notifications/entities/notification-recipient.entity.ts
@@ -23,8 +23,7 @@ export class NotificationRecipient extends BaseEntity {
   user: Relation<User>;
 
   @Column({
-    type: 'enum',
-    enum: NotificationStatus,
+    type: 'varchar',
     default: NotificationStatus.SENT,
   })
   status: NotificationStatus;

--- a/core-api/src/modules/notifications/entities/notification.entity.ts
+++ b/core-api/src/modules/notifications/entities/notification.entity.ts
@@ -6,10 +6,10 @@ import { Column, Entity, Index, JoinColumn, ManyToOne, Relation } from 'typeorm'
 @Entity('notifications')
 @Index('IDX_notifications_workspaceId', ['workspace'])
 export class Notification extends BaseEntity {
-  @Column({ type: 'enum', enum: NotificationScope })
+  @Column({ type: 'varchar' })
   scope: NotificationScope;
 
-  @Column({ type: 'enum', enum: NotificationType })
+  @Column({ type: 'varchar' })
   type: NotificationType;
 
   @Column('jsonb')

--- a/core-api/src/modules/reports/entities/report.entity.ts
+++ b/core-api/src/modules/reports/entities/report.entity.ts
@@ -16,8 +16,7 @@ export class Report extends BaseEntity {
   user: Relation<User>;
 
   @Column({
-    type: 'enum',
-    enum: ['SUMMARY', 'VULNERABILITY'],
+    type: 'varchar',
     default: 'SUMMARY',
   })
   type: 'SUMMARY' | 'VULNERABILITY';

--- a/core-api/src/modules/targets/entities/target.entity.ts
+++ b/core-api/src/modules/targets/entities/target.entity.ts
@@ -73,8 +73,7 @@ export class Target extends BaseEntity {
   })
   @IsEnum(TargetType)
   @Column({
-    type: 'enum',
-    enum: TargetType,
+    type: 'varchar',
     default: TargetType.DOMAIN,
   })
   type: TargetType;
@@ -103,8 +102,7 @@ export class Target extends BaseEntity {
   @IsOptional()
   @IsEnum(CronSchedule)
   @Column({
-    type: 'enum',
-    enum: CronSchedule,
+    type: 'varchar',
     default: CronSchedule.DISABLED,
     nullable: true,
   })

--- a/core-api/src/modules/tools/entities/tools.entity.ts
+++ b/core-api/src/modules/tools/entities/tools.entity.ts
@@ -61,7 +61,7 @@ export class Tool {
 
   @ApiProperty({ enum: ToolCategory })
   @IsEnum(ToolCategory)
-  @Column({ type: 'enum', enum: ToolCategory })
+  @Column({ type: 'varchar' })
   category?: ToolCategory;
 
   @ApiProperty()
@@ -91,7 +91,7 @@ export class Tool {
   isOfficialSupport?: boolean;
 
   @ApiProperty()
-  @Column({ type: 'enum', enum: WorkerType, default: WorkerType.BUILT_IN })
+  @Column({ type: 'varchar', default: WorkerType.BUILT_IN })
   @IsEnum(WorkerType)
   type?: WorkerType;
 
@@ -127,7 +127,7 @@ export class Tool {
   @OneToMany(() => WorkerInstance, (workerInstance) => workerInstance.tool)
   workers?: Relation<WorkerInstance[]>;
 
-  @Column({ type: 'enum', enum: JobPriority, default: JobPriority.BACKGROUND })
+  @Column({ type: 'varchar', default: JobPriority.BACKGROUND })
   priority?: JobPriority;
 
   @ApiProperty({ required: false })

--- a/core-api/src/modules/vulnerabilities/entities/vulnerability-dismissal.entity.ts
+++ b/core-api/src/modules/vulnerabilities/entities/vulnerability-dismissal.entity.ts
@@ -25,7 +25,7 @@ export class VulnerabilityDismissal extends BaseEntity {
   userId: string;
 
   @ApiProperty()
-  @Column({ type: 'enum', enum: DismissReason })
+  @Column({ type: 'varchar' })
   reason: DismissReason;
 
   @ApiProperty()

--- a/core-api/src/modules/vulnerabilities/entities/vulnerability.entity.ts
+++ b/core-api/src/modules/vulnerabilities/entities/vulnerability.entity.ts
@@ -37,7 +37,7 @@ export class Vulnerability extends BaseEntity {
   synopsis?: string;
 
   @ApiProperty()
-  @Column({ type: 'enum', enum: Severity, default: Severity.INFO })
+  @Column({ type: 'varchar', default: Severity.INFO })
   severity: Severity;
 
   @ApiProperty()
@@ -180,7 +180,7 @@ export class Vulnerability extends BaseEntity {
   vulnerabilityDismissal: Relation<VulnerabilityDismissal>;
 
   @ApiProperty({ enum: VulnerabilityAnalyzeStatus })
-  @Column({ type: 'enum', enum: VulnerabilityAnalyzeStatus, default: VulnerabilityAnalyzeStatus.NOT_ANALYZED })
+  @Column({ type: 'varchar', default: VulnerabilityAnalyzeStatus.NOT_ANALYZED })
   analyzeStatus: VulnerabilityAnalyzeStatus;
 
   @ApiProperty()

--- a/core-api/src/modules/workers/entities/worker.entity.ts
+++ b/core-api/src/modules/workers/entities/worker.entity.ts
@@ -38,11 +38,11 @@ export class WorkerInstance extends BaseEntity {
   currentJobsCount?: number;
 
   @ApiProperty()
-  @Column({ type: 'enum', enum: WorkerType, default: WorkerType.BUILT_IN })
+  @Column({ type: 'varchar', default: WorkerType.BUILT_IN })
   type: WorkerType;
 
   @ApiProperty()
-  @Column({ type: 'enum', enum: WorkerScope, default: WorkerScope.WORKSPACE })
+  @Column({ type: 'varchar', default: WorkerScope.WORKSPACE })
   scope: WorkerScope;
 
   @Column({ type: 'uuid', nullable: true })

--- a/core-api/src/modules/workspaces/entities/workspace-members.entity.ts
+++ b/core-api/src/modules/workspaces/entities/workspace-members.entity.ts
@@ -20,6 +20,6 @@ export class WorkspaceMembers extends BaseEntity {
   })
   user: Relation<User>;
 
-  @Column({ type: 'enum', enum: WorkspaceRole, default: WorkspaceRole.OWNER })
+  @Column({ type: 'varchar', default: WorkspaceRole.OWNER })
   role: WorkspaceRole;
 }


### PR DESCRIPTION
Replace all PostgreSQL enum column types with varchar across 19 entities to reduce coupling to specific DB features. Fix migration to use ALTER COLUMN TYPE (safe in-place) instead of DROP/ADD COLUMN to preserve existing data and constraints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database compatibility and upgrade reliability for status, role, type, priority, and scheduling values across core features.
  * Preserved existing defaults and application-level validation while migrating stored values to a more flexible format.
  * Updated related database indexes and constraints to remain functional after the migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->