### PR TITLE
feat(integrations): implement telegram bot command framework

### DIFF
--- a/core-api/package.json
+++ b/core-api/package.json
@@ -71,6 +71,7 @@
     "mustache": "^4.2.0",
     "nanoid": "^3.3.8",
     "nestjs-i18n": "^10.6.0",
+    "node-telegram-bot-api": "^1.2.0",
     "pg": "^8.16.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/core-api/src/modules/integrations/integrations.controller.ts
+++ b/core-api/src/modules/integrations/integrations.controller.ts
@@ -215,8 +215,21 @@ export class IntegrationsController {
     @Param('integrationId') integrationId: string,
     @Body() update: unknown,
   ) {
+    // Resolve bot token so /start without token can reply with instructions
+    let botToken: string | undefined;
+    try {
+      const { decryptedConfig } =
+        await this.integrationsService.getDecryptedIntegrationById(
+          integrationId,
+        );
+      botToken = decryptedConfig.botToken as string | undefined;
+    } catch {
+      // Integration not found or decryption failed — proceed without botToken
+    }
+
     await this.telegramWebhookService.processUpdate(
       update as Parameters<TelegramWebhookService['processUpdate']>[0],
+      { botToken, integrationId },
     );
     return { ok: true };
   }
@@ -259,6 +272,11 @@ export class IntegrationsController {
     @WorkspaceId() workspaceId: string,
     @UserId() userId: string,
   ) {
-    return this.telegramConnectService.disconnect(connectId, id, workspaceId, userId);
+    return this.telegramConnectService.disconnect(
+      connectId,
+      id,
+      workspaceId,
+      userId,
+    );
   }
 }

--- a/core-api/src/modules/integrations/integrations.module.ts
+++ b/core-api/src/modules/integrations/integrations.module.ts
@@ -8,6 +8,7 @@ import { IntegrationsService } from './integrations.service';
 import { TelegramConnectService } from './telegram-connect.service';
 import { TelegramWebhookService } from './telegram-webhook.service';
 import { TelegramPollingService } from './telegram-polling.service';
+import { TelegramBotService } from './telegram-bot.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Integration, TelegramConnect, User])],
@@ -17,6 +18,7 @@ import { TelegramPollingService } from './telegram-polling.service';
     TelegramConnectService,
     TelegramWebhookService,
     TelegramPollingService,
+    TelegramBotService,
   ],
   exports: [IntegrationsService, TelegramConnectService],
 })

--- a/core-api/src/modules/integrations/telegram-bot.service.ts
+++ b/core-api/src/modules/integrations/telegram-bot.service.ts
@@ -1,0 +1,74 @@
+import { Injectable, Logger } from '@nestjs/common';
+import TelegramBot from 'node-telegram-bot-api';
+
+/**
+ * Shared service for interacting with the Telegram Bot API.
+ * Caches TelegramBot instances per token (send-only, no polling).
+ */
+@Injectable()
+export class TelegramBotService {
+  private readonly logger = new Logger(TelegramBotService.name);
+
+  /** Cached bot instances keyed by token. */
+  private readonly bots = new Map<string, TelegramBot>();
+
+  private getBot(token: string): TelegramBot {
+    let bot = this.bots.get(token);
+    if (!bot) {
+      bot = new TelegramBot(token);
+      this.bots.set(token, bot);
+    }
+    return bot;
+  }
+
+  /**
+   * Sends an HTML-formatted text message to a Telegram chat.
+   */
+  async sendMessage(
+    botToken: string,
+    chatId: string,
+    text: string,
+  ): Promise<void> {
+    try {
+      await this.getBot(botToken).sendMessage(chatId, text, {
+        parse_mode: 'HTML',
+        link_preview_options: { is_disabled: true },
+      });
+    } catch (err) {
+      this.logger.warn(
+        `Failed send Telegram message ${chatId}: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  /**
+   * Registers bot commands with Telegram so users see the command menu.
+   */
+  async setMyCommands(
+    botToken: string,
+    commands: Array<{ command: string; description: string }>,
+  ): Promise<boolean> {
+    try {
+      return await this.getBot(botToken).setMyCommands(commands, {
+        scope: { type: 'default' },
+      });
+    } catch (err) {
+      this.logger.warn(
+        `Failed sync bot commands: ${(err as Error).message}`,
+      );
+      return false;
+    }
+  }
+
+  /**
+   * Calls getMe to validate the bot token and return the bot username.
+   * Throws if the token is invalid.
+   */
+  async getMe(botToken: string): Promise<{ username: string }> {
+    const result = await this.getBot(botToken).getMe();
+    if (!result.username) {
+      throw new Error('Telegram getMe returned no username');
+    }
+    return { username: result.username };
+  }
+}

--- a/core-api/src/modules/integrations/telegram-connect.service.ts
+++ b/core-api/src/modules/integrations/telegram-connect.service.ts
@@ -1,7 +1,6 @@
 import {
   BadRequestException,
   Injectable,
-  InternalServerErrorException,
   Logger,
   NotFoundException,
   OnModuleInit,
@@ -16,9 +15,9 @@ import { TelegramConnector } from './connectors/telegram.connector';
 import { Integration } from './entities/integration.entity';
 import { TelegramConnect } from './entities/telegram-connect.entity';
 import { IntegrationsService } from './integrations.service';
+import { TelegramBotService } from './telegram-bot.service';
 import type { TelegramConnectDto } from './dto/telegram-connect.dto';
 
-const TELEGRAM_API_BASE = 'https://api.telegram.org';
 const CONNECT_TOKEN_LENGTH = 48;
 const TOKEN_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
@@ -35,6 +34,7 @@ export class TelegramConnectService implements OnModuleInit {
     private readonly userRepo: Repository<User>,
     private readonly integrationsService: IntegrationsService,
     private readonly workspacesService: WorkspacesService,
+    private readonly telegramBotService: TelegramBotService,
   ) {}
 
   /**
@@ -122,20 +122,8 @@ export class TelegramConnectService implements OnModuleInit {
    * Throws if the bot token is invalid or the API call fails.
    */
   private async fetchBotUsername(botToken: string): Promise<string> {
-    const url = `${TELEGRAM_API_BASE}/bot${botToken}/getMe`;
-    const response = await fetch(url, { signal: AbortSignal.timeout(10_000) });
-    if (!response.ok) {
-      throw new InternalServerErrorException(
-        `Telegram bot token is invalid or the bot does not exist (HTTP ${response.status})`,
-      );
-    }
-    const data = (await response.json()) as { ok: boolean; result?: { username?: string } };
-    if (!data.ok || !data.result?.username) {
-      throw new InternalServerErrorException(
-        'Telegram API returned an unexpected response for getMe',
-      );
-    }
-    return data.result.username;
+    const { username } = await this.telegramBotService.getMe(botToken);
+    return username;
   }
 
   /**
@@ -171,7 +159,7 @@ export class TelegramConnectService implements OnModuleInit {
     if (!connect) {
       // Try to notify the user even without a valid connect record
       if (botToken) {
-        await this.sendTelegramMessage(
+        await this.telegramBotService.sendMessage(
           botToken,
           chatInfo.chatId,
           '❌ <b>Connection Failed</b>\n\nThe pairing token is invalid or has expired. Please generate a new pairing code in OpenASM and try again.',
@@ -195,7 +183,7 @@ export class TelegramConnectService implements OnModuleInit {
       await this.connectRepo.delete(connect.id);
 
       if (botToken) {
-        await this.sendTelegramMessage(
+        await this.telegramBotService.sendMessage(
           botToken,
           chatInfo.chatId,
           '🔁 <b>Already Connected</b>\n\nThis Telegram account is already linked to your workspace. You are already receiving notifications here.\n\nIf you want to reconnect, please disconnect first from the OpenASM dashboard.',
@@ -208,7 +196,7 @@ export class TelegramConnectService implements OnModuleInit {
 
     if (connect.tokenExpiredAt && connect.tokenExpiredAt < new Date()) {
       if (botToken) {
-        await this.sendTelegramMessage(
+        await this.telegramBotService.sendMessage(
           botToken,
           chatInfo.chatId,
           '❌ <b>Connection Failed</b>\n\nThis pairing token has expired. Please generate a new pairing code in OpenASM and try again.',
@@ -260,7 +248,7 @@ export class TelegramConnectService implements OnModuleInit {
       const escapedWs = this.escapeHtml(workspaceName);
       const escapedName = this.escapeHtml(displayName);
       const escapedUser = this.escapeHtml(appUserName);
-      await this.sendTelegramMessage(
+      await this.telegramBotService.sendMessage(
         botToken,
         chatInfo.chatId,
         `🎉 <b>Connected to ${escapedWs}!</b>
@@ -342,7 +330,7 @@ You'll now receive security alerts and notifications here. Stay safe! 🔒`,
       }
       if (botToken) {
         const escapedWs = this.escapeHtml(workspaceName);
-        await this.sendTelegramMessage(
+        await this.telegramBotService.sendMessage(
           botToken,
           connect.telegramChatId,
           `🔌 <b>Disconnected from ${escapedWs}</b>\n\nThis chat has been disconnected from <b>${escapedWs}</b>. You will no longer receive security alerts here.\n\nIf you'd like to reconnect, generate a new pairing code in OpenASM.`,
@@ -370,36 +358,24 @@ You'll now receive security alerts and notifications here. Stay safe! 🔒`,
   }
 
   /**
-   * Sends an HTML-formatted message to a Telegram chat via the Bot API.
+   * Disconnects a Telegram chat by chat ID and integration ID.
+   * Returns true if a connection was found and deleted, false otherwise.
    */
-  private async sendTelegramMessage(
-    botToken: string,
+  async disconnectByChatId(
     chatId: string,
-    text: string,
-  ): Promise<void> {
-    const url = `${TELEGRAM_API_BASE}/bot${botToken}/sendMessage`;
-    try {
-      const response = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        signal: AbortSignal.timeout(10_000),
-        body: JSON.stringify({
-          chat_id: chatId,
-          text,
-          parse_mode: 'HTML',
-          disable_web_page_preview: true,
-        }),
-      });
-      if (!response.ok) {
-        this.logger.warn(
-          `Failed to send Telegram message to ${chatId}: HTTP ${response.status}`,
-        );
-      }
-    } catch (err) {
-      this.logger.warn(
-        `Failed to send Telegram message to ${chatId}: ${(err as Error).message}`,
-      );
-    }
+    integrationId: string,
+  ): Promise<boolean> {
+    const connect = await this.connectRepo.findOne({
+      where: {
+        telegramChatId: chatId,
+        integrationId,
+        status: TelegramConnectStatus.CONNECTED,
+        isActive: true,
+      },
+    });
+    if (!connect) return false;
+    await this.connectRepo.delete(connect.id);
+    return true;
   }
 
   /**

--- a/core-api/src/modules/integrations/telegram-polling.service.ts
+++ b/core-api/src/modules/integrations/telegram-polling.service.ts
@@ -139,7 +139,7 @@ export class TelegramPollingService implements OnApplicationBootstrap {
         if (signal?.aborted) return;
 
         try {
-          await this.telegramWebhookService.processUpdate(update);
+          await this.telegramWebhookService.processUpdate(update, { botToken, integrationId: integration.id });
         } catch (err) {
           this.logger.error('Error processing polling update', err);
         }

--- a/core-api/src/modules/integrations/telegram-webhook.service.ts
+++ b/core-api/src/modules/integrations/telegram-webhook.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { TelegramConnectService } from './telegram-connect.service';
+import { TelegramBotService } from './telegram-bot.service';
 
 interface TelegramUpdate {
   update_id: number;
@@ -30,50 +31,188 @@ interface TelegramUpdate {
   };
 }
 
+interface CommandContext {
+  chatId: string;
+  botToken?: string;
+  integrationId?: string;
+  firstName?: string;
+}
+
+interface BotCommand {
+  command: string;
+  description: string;
+  fn: (args: string, ctx: CommandContext) => Promise<void>;
+}
+
 @Injectable()
 export class TelegramWebhookService {
   private readonly logger = new Logger(TelegramWebhookService.name);
 
+  /** Tracks botTokens whose commands have already been synced to Telegram. */
+  private readonly syncedBots = new Set<string>();
+
+  private readonly commands: BotCommand[] = [
+    {
+      command: 'pair',
+      description: 'Connect this chat to OpenASM',
+      fn: (args, ctx) => this.handlePair(args, ctx),
+    },
+    {
+      command: 'unpair',
+      description: 'Disconnect this chat from OpenASM',
+      fn: (_args, ctx) => this.handleUnpair(ctx),
+    },
+    {
+      command: 'help',
+      description: 'Show available commands',
+      fn: (_args, ctx) => this.handleHelp(ctx),
+    },
+  ];
+
   constructor(
     private readonly telegramConnectService: TelegramConnectService,
+    private readonly telegramBotService: TelegramBotService,
   ) {}
 
   /**
    * Processes a Telegram update sent to the webhook endpoint.
-   * Handles /start <token> commands to pair a Telegram chat with a user.
+   * Dispatches to registered commands. /start is an alias for /pair
+   * (Telegram deep link t.me/bot?start=TOKEN requires /start).
    */
-  async processUpdate(update: TelegramUpdate): Promise<void> {
+  async processUpdate(
+    update: TelegramUpdate,
+    options?: { botToken?: string; integrationId?: string },
+  ): Promise<void> {
     const message = update.message;
     if (!message?.text) return;
 
-    // Parse /start <token> or /start
-    const text = message.text.trim();
-    if (!text.startsWith('/start')) return;
+    // Lazy sync: register commands with Telegram on first update per bot
+    if (options?.botToken && !this.syncedBots.has(options.botToken)) {
+      const synced = await this.telegramBotService.setMyCommands(
+        options.botToken,
+        this.commands.map((c) => ({
+          command: c.command,
+          description: c.description,
+        })),
+      );
+      if (synced) {
+        this.syncedBots.add(options.botToken);
+      }
+    }
 
-    const token = text.split(/\s+/)[1];
-    if (!token) {
-      this.logger.debug('Ignored /start without token');
+    const text = message.text.trim();
+    const chatId = String(message.chat.id);
+
+    // Parse command: /command or /command@botname args
+    const match = text.match(/^\/(\w+)(?:@\w+)?\s*(.*)/s);
+    if (!match) return;
+
+    const [, cmdName, rawArgs] = match;
+    const args = rawArgs.trim();
+    const ctx: CommandContext = {
+      chatId,
+      botToken: options?.botToken,
+      integrationId: options?.integrationId,
+      firstName: message.from?.first_name,
+    };
+
+    // /start is an alias for /pair (Telegram deep link compatibility)
+    if (cmdName === 'start') {
+      await this.handlePair(args, ctx);
       return;
     }
 
-    const chatId = String(message.chat.id);
+    const command = this.commands.find((c) => c.command === cmdName);
+    if (command) {
+      await command.fn(args, ctx);
+    }
+  }
+
+  private async handlePair(args: string, ctx: CommandContext): Promise<void> {
+    if (!args) {
+      const firstName = ctx.firstName ?? 'there';
+      const instruction =
+        `👋 Hi ${firstName}!\n\n` +
+        `To connect your Telegram chat to OpenASM, you need to send a pairing token.\n\n` +
+        `📋 <b>How to connect:</b>\n` +
+        `1. Open OpenASM Console → Integrations → Telegram\n` +
+        `2. Click <b>"Pair"</b> to generate a pairing token\n` +
+        `3. Send the token here:\n` +
+        `   <code>/pair &lt;your-token&gt;</code>\n\n` +
+        `❓ If you need help, type /help`;
+
+      if (ctx.botToken) {
+        await this.telegramBotService.sendMessage(
+          ctx.botToken,
+          ctx.chatId,
+          instruction,
+        );
+      }
+      return;
+    }
 
     try {
-      await this.telegramConnectService.confirmConnection(token, {
-        chatId,
-        username: message.chat.username ?? message.from?.username,
-        firstName: message.chat.first_name ?? message.from?.first_name,
-        lastName: message.chat.last_name ?? message.from?.last_name,
+      await this.telegramConnectService.confirmConnection(args, {
+        chatId: ctx.chatId,
+        username: undefined,
+        firstName: ctx.firstName,
       });
-
-      this.logger.log(
-        `Telegram chat ${chatId} connected via token`,
-      );
+      this.logger.log(`Telegram chat ${ctx.chatId} connected via pair command`);
     } catch (error: unknown) {
       const err = error as Error;
       this.logger.warn(
-        `Failed to connect Telegram chat ${chatId}: ${err.message}`,
+        `Failed to connect Telegram chat ${ctx.chatId}: ${err.message}`,
       );
     }
+  }
+
+  private async handleUnpair(ctx: CommandContext): Promise<void> {
+    if (!ctx.integrationId || !ctx.botToken) {
+      this.logger.debug(
+        'Cannot process /unpair: missing integrationId or botToken',
+      );
+      return;
+    }
+
+    const removed = await this.telegramConnectService.disconnectByChatId(
+      ctx.chatId,
+      ctx.integrationId,
+    );
+
+    if (removed) {
+      await this.telegramBotService.sendMessage(
+        ctx.botToken,
+        ctx.chatId,
+        '🔌 <b>Disconnected</b>\n\nThis chat has been disconnected from OpenASM. You will no longer receive security alerts here.\n\nIf you\'d like to reconnect, generate a new pairing code in OpenASM.',
+      );
+      this.logger.log(
+        `Telegram chat ${ctx.chatId} disconnected via /unpair`,
+      );
+    } else {
+      await this.telegramBotService.sendMessage(
+        ctx.botToken,
+        ctx.chatId,
+        'ℹ️ <b>Not Connected</b>\n\nThis chat is not currently connected to any OpenASM workspace.\n\nTo connect, send /pair with your pairing token.',
+      );
+    }
+  }
+
+  private async handleHelp(ctx: CommandContext): Promise<void> {
+    if (!ctx.botToken) return;
+
+    const commandList = this.commands
+      .map((c) => `  /${c.command} — ${c.description}`)
+      .join('\n');
+
+    const helpText =
+      `📖 <b>Available Commands</b>\n\n` +
+      `${commandList}\n\n` +
+      `💡 <b>Note:</b> You can also use <code>/start &lt;token&gt;</code> (same as /pair) — this is required when connecting via link.`;
+
+    await this.telegramBotService.sendMessage(
+      ctx.botToken,
+      ctx.chatId,
+      helpText,
+    );
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,6 +82,7 @@
         "next-themes": "^0.4.6",
         "orval": "^8.9.1",
         "prettier": "^3.6.2",
+        "qrcode.react": "^4.2.0",
         "qs": "^6.14.1",
         "radix-ui": "^1.4.3",
         "react": "^19.1.0",
@@ -134,7 +135,6 @@
         "husky": "^9.1.7",
         "jsdom": "^26.1.0",
         "msw": "^2.14.6",
-        "qrcode.react": "^4.2.0",
         "react-router-dom": "^7.6.2",
         "tw-animate-css": "^1.3.4",
         "typescript": "~5.8.3",
@@ -290,6 +290,7 @@
         "mustache": "^4.2.0",
         "nanoid": "^3.3.8",
         "nestjs-i18n": "^10.6.0",
+        "node-telegram-bot-api": "^1.2.0",
         "pg": "^8.16.0",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
@@ -23572,6 +23573,15 @@
       "version": "2.0.36",
       "license": "MIT"
     },
+    "node_modules/node-telegram-bot-api": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/node-telegram-bot-api/-/node-telegram-bot-api-1.2.0.tgz",
+      "integrity": "sha512-M6S61LZn1FQMQnZSdFlc4oV+mwDGlPTbLzq/GUaSH4ew40wGTaKPtAaLp5oOhl/C3k0ylGqMIppJsVulwTCePg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/nopt": {
       "version": "8.1.0",
       "dev": true,
@@ -24974,7 +24984,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
       "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
-      "dev": true,
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"


### PR DESCRIPTION
- Add TelegramBotService for centralized bot API interactions
- Register /pair, /unpair, and /help commands
- Map /start to /pair for deep link support
- Improve user instructions for connection process

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Telegram bot support for sending messages and validating bot connections.
  * Added Telegram commands for pairing, disconnecting, and viewing available help.
  * Added support for registering bot commands automatically.
  * Added `/start <token>` compatibility for existing pairing flows.
* **Improvements**
  * Telegram connection and webhook flows now provide clearer responses for successful, unsuccessful, and invalid actions.
  * Pairing instructions are shown when the pairing command is used without a token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->