### PR TITLE
fix(console): resolve login race condition

### DIFF
--- a/console/src/main.tsx
+++ b/console/src/main.tsx
@@ -135,13 +135,10 @@ function AppRouter() {
       return;
     }
 
-    // Only invalidate on session refresh/switch (valid → valid).
-    // Skip on first load (null → valid) — RouterProvider already resolved
-    // routes with the correct context, and invalidate() can cause a brief
-    // stale-context re-resolution that flashes /login.
-    if (prevSession) {
-      router.invalidate();
-    }
+    // Invalidate on any session state change (null→valid, valid→valid).
+    // This re-evaluates route guards so _authed.beforeLoad sees the
+    // current session and login.tsx:beforeLoad redirects away from /login.
+    router.invalidate();
   }, [session]);
 
   // Wait for session to load before rendering the router.

--- a/console/src/pages/login/login.tsx
+++ b/console/src/pages/login/login.tsx
@@ -11,7 +11,6 @@ import {
 import { Input } from '@/components/ui/input';
 import { authClient } from '@/utils/authClient';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { getRouteApi, useNavigate } from '@tanstack/react-router';
 import { Loader2Icon } from 'lucide-react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -22,10 +21,7 @@ const formSchema = z.object({
   password: z.string().min(8, 'Password must be at least 8 characters'),
 });
 
-const routeApi = getRouteApi('/login');
-
 export default function Login() {
-  const { redirect: redirectUrl } = routeApi.useSearch();
   const form = useForm({
     resolver: zodResolver(formSchema),
     defaultValues: {
@@ -35,7 +31,6 @@ export default function Login() {
   });
 
   const [loading, setLoading] = useState(false);
-  const navigate = useNavigate();
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
     setLoading(true);
@@ -44,7 +39,10 @@ export default function Login() {
       password: values.password,
       fetchOptions: {
         onSuccess: async () => {
-          await navigate({ to: redirectUrl || '/', replace: true });
+          // Don't navigate here — session hasn't propagated to
+          // RouterProvider context yet. Let AppRouter's effect call
+          // router.invalidate() after useSession() updates, which
+          // re-runs login.tsx:beforeLoad and redirects to '/'.
         },
         onError: (ctx) => {
           form.setError('password', {
@@ -82,7 +80,7 @@ export default function Login() {
                   <FormItem>
                     <FormLabel>Email</FormLabel>
                     <FormControl>
-                      <Input placeholder="email@example.com" {...field} />
+                      <Input placeholder="email@example.com" className="h-10" {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>
@@ -98,6 +96,7 @@ export default function Login() {
                       <Input
                         type="password"
                         placeholder="••••••••"
+                        className="h-10"
                         {...field}
                       />
                     </FormControl>


### PR DESCRIPTION
Remove premature navigate() in login onSuccess callback that fired before AppRouter re-rendered with the new session, causing _authed beforeLoad to see stale null context and redirect back to /login.

Enable router.invalidate() on null→valid session transition so route guards re-evaluate after first login. Increase input height to h-10 to match the Sign in button (size=lg).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session state handling during authentication flow.

* **Style**
  * Updated login input field height styling for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->