### PR TITLE
feat(console): add search filters and navigation to members settings

### DIFF
--- a/console/src/__tests__/pages/members-settings.test.tsx
+++ b/console/src/__tests__/pages/members-settings.test.tsx
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderWithProviders, screen, waitFor } from '@/test/utils';
+import MembersSettings from '@/pages/settings/components/members-settings';
+
+const { mockGroups, mockInvitations } = vi.hoisted(() => ({
+  mockGroups: vi.fn(),
+  mockInvitations: vi.fn(),
+}));
+
+vi.mock('@/hooks/usePermission', () => ({
+  usePermission: () => ({
+    permissions: ['*'],
+    isOwner: true,
+    hasPermission: () => true,
+    isLoading: false,
+    isFetching: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useWorkspaceSelector', () => ({
+  useWorkspaceState: () => ({ state: { selectedWorkspaceId: 'ws-1' } }),
+}));
+
+vi.mock('@/services/apis/gen/queries', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('@/services/apis/gen/queries')
+  >();
+  const emptyQuery = () => ({
+    data: [],
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  });
+  return {
+    ...actual,
+    useWorkspacesControllerGetWorkspaceMembers: () => ({
+      ...emptyQuery(),
+      data: [],
+    }),
+    useWorkspacesControllerGetPermissionGroups: () => ({
+      ...emptyQuery(),
+      data: mockGroups(),
+    }),
+    useWorkspacesControllerListInvitations: () => ({
+      ...emptyQuery(),
+      data: mockInvitations(),
+    }),
+    useWorkspacesControllerRemoveMember: () => ({
+      mutate: vi.fn(),
+      isPending: false,
+    }),
+    useWorkspacesControllerCancelInvitation: () => ({
+      mutate: vi.fn(),
+      isPending: false,
+    }),
+    useWorkspacesControllerCreateInvitations: () => ({
+      mutate: vi.fn(),
+      isPending: false,
+    }),
+    useWorkspacesControllerDeletePermissionGroup: () => ({
+      mutate: vi.fn(),
+      isPending: false,
+    }),
+    useWorkspacesControllerUpdateMemberPermissions: () => ({
+      mutate: vi.fn(),
+      isPending: false,
+    }),
+  };
+});
+
+beforeEach(() => {
+  mockGroups.mockReturnValue([]);
+  mockInvitations.mockReturnValue([]);
+});
+
+describe('MembersSettings invite dialog', () => {
+  it('renders the search input, Invite member and Create group buttons with equal heights', async () => {
+    const { user } = renderWithProviders(<MembersSettings />, {
+      routePath: '/settings/members',
+      initialEntries: ['/settings/members?tab=permissions'],
+    });
+
+    const createGroupButton = await screen.findByRole('button', {
+      name: 'Create group',
+    });
+    expect(createGroupButton.className).toMatch(/(^|s)h-9(s|$)/);
+
+    // Switch to the members tab to check the search input + invite button.
+    await user.click(screen.getByRole('tab', { name: 'Members' }));
+    const searchInput = await screen.findByPlaceholderText('Search members...');
+    const inviteButton = screen.getByRole('button', { name: 'Invite member' });
+
+    expect(searchInput.className).toMatch(/(^|s)h-9(s|$)/);
+    expect(inviteButton.className).toMatch(/(^|s)h-9(s|$)/);
+  });
+
+  it('filters invitations by email in the Invitations tab', async () => {
+    mockInvitations.mockReturnValue([
+      {
+        id: 'i-1',
+        email: 'alice@example.com',
+        status: 'pending',
+        expiresAt: '2026-01-01T00:00:00Z',
+        permissionIds: [],
+      },
+      {
+        id: 'i-2',
+        email: 'bob@example.com',
+        status: 'pending',
+        expiresAt: '2026-01-02T00:00:00Z',
+        permissionIds: [],
+      },
+    ]);
+
+    const { user } = renderWithProviders(<MembersSettings />, {
+      routePath: '/settings/members',
+    });
+
+    await user.click(await screen.findByRole('tab', { name: 'Invitations' }));
+    const input = await screen.findByPlaceholderText('Search invitations...');
+    await user.type(input, 'alice');
+
+    expect(screen.getByText('alice@example.com')).toBeInTheDocument();
+    expect(screen.queryByText('bob@example.com')).not.toBeInTheDocument();
+  });
+
+  it('filters permission groups by name in the Permissions tab', async () => {
+    mockGroups.mockReturnValue([
+      {
+        id: 'g-1',
+        name: 'Viewers',
+        permissions: ['target.read'],
+        isSystem: false,
+      },
+      {
+        id: 'g-2',
+        name: 'Editors',
+        permissions: ['target.write'],
+        isSystem: false,
+      },
+    ]);
+
+    const { user } = renderWithProviders(<MembersSettings />, {
+      routePath: '/settings/members',
+      initialEntries: ['/settings/members?tab=permissions'],
+    });
+
+    const input = await screen.findByPlaceholderText(
+      'Search permission groups...',
+    );
+    await user.type(input, 'edit');
+
+    expect(screen.getByText('Editors')).toBeInTheDocument();
+    expect(screen.queryByText('Viewers')).not.toBeInTheDocument();
+  });
+
+  it('shows a link to the Permissions tab when no permission groups exist', async () => {
+    const { user } = renderWithProviders(<MembersSettings />, {
+      routePath: '/settings/members',
+    });
+
+    await user.click(await screen.findByRole('button', { name: 'Invite member' }));
+
+    expect(
+      await screen.findByRole('button', {
+        name: 'Create one in the Permissions tab.',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the link when only the system Admin group exists (no invitable groups)', async () => {
+    mockGroups.mockReturnValue([
+      {
+        id: 'sys-1',
+        name: 'Admin',
+        permissions: ['*'],
+        isSystem: true,
+      },
+    ]);
+
+    const { user } = renderWithProviders(<MembersSettings />, {
+      routePath: '/settings/members',
+    });
+
+    await user.click(await screen.findByRole('button', { name: 'Invite member' }));
+
+    expect(
+      await screen.findByRole('button', {
+        name: 'Create one in the Permissions tab.',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('checkbox', { name: /Admin/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('clicking the link navigates to the permissions tab and closes the dialog', async () => {
+    const { user, router } = renderWithProviders(<MembersSettings />, {
+      routePath: '/settings/members',
+    });
+
+    await user.click(await screen.findByRole('button', { name: 'Invite member' }));
+    await user.click(
+      await screen.findByRole('button', {
+        name: 'Create one in the Permissions tab.',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/settings/members');
+      expect(router.state.location.search.tab).toBe('permissions');
+    });
+    // Dialog closed: Permissions tab content is visible, invite dialog is not.
+    expect(await screen.findByRole('button', { name: 'Create group' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Send invitations' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('lists permission groups as checkboxes when groups exist (no link)', async () => {
+    mockGroups.mockReturnValue([
+      {
+        id: 'g-1',
+        name: 'Viewers',
+        permissions: ['target.read'],
+        isSystem: false,
+      },
+    ]);
+
+    const { user } = renderWithProviders(<MembersSettings />, {
+      routePath: '/settings/members',
+    });
+
+    await user.click(await screen.findByRole('button', { name: 'Invite member' }));
+
+    expect(
+      await screen.findByRole('checkbox', { name: /Viewers/ }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('target.read')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {
+        name: 'Create one in the Permissions tab.',
+      }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/console/src/pages/settings/components/members-settings.tsx
+++ b/console/src/pages/settings/components/members-settings.tsx
@@ -186,7 +186,6 @@ function MembersTab({ workspaceId }: { workspaceId: string }) {
         queryClient.invalidateQueries({ queryKey: ['/api/workspaces/members'] });
         invalidateWorkspaceQueries(queryClient);
       },
-      onError: () => toast.error('Failed to remove member'),
     },
   });
 
@@ -304,12 +303,12 @@ function MembersTab({ workspaceId }: { workspaceId: string }) {
           placeholder="Search members..."
           value={search}
           onChange={(event) => setSearch(event.target.value)}
-          className="max-w-xs"
+          className="h-9 max-w-xs"
         />
         {canInvite && (
           <Dialog open={inviteOpen} onOpenChange={setInviteOpen}>
             <DialogTrigger asChild>
-              <Button size="sm">
+              <Button size="sm" className="h-9">
                 <UserPlus className="h-4 w-4" />
                 Invite member
               </Button>
@@ -362,6 +361,7 @@ function MembersTab({ workspaceId }: { workspaceId: string }) {
 
 function InvitationsTab({ workspaceId }: { workspaceId: string }) {
   const queryClient = useQueryClient();
+  const [search, setSearch] = useState('');
   const { hasPermission } = usePermission();
   const {
     data: invitations,
@@ -381,11 +381,18 @@ function InvitationsTab({ workspaceId }: { workspaceId: string }) {
         toast.success('Invitation cancelled');
         invalidateWorkspaceQueries(queryClient);
       },
-      onError: () => toast.error('Failed to cancel invitation'),
     },
   });
 
   const canManageInvites = hasPermission('invitation.write');
+
+  const filteredInvitations = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return invitations ?? [];
+    return (invitations ?? []).filter((invitation) =>
+      invitation.email.toLowerCase().includes(query),
+    );
+  }, [invitations, search]);
 
   const { data: permissionGroups } = useWorkspacesControllerGetPermissionGroups({
     query: {
@@ -406,7 +413,6 @@ function InvitationsTab({ workspaceId }: { workspaceId: string }) {
         toast.success('Invitation resent');
         invalidateWorkspaceQueries(queryClient);
       },
-      onError: () => toast.error('Failed to resend invitation'),
     },
   });
 
@@ -517,22 +523,34 @@ function InvitationsTab({ workspaceId }: { workspaceId: string }) {
   }
 
   return (
-    <DataTable
-      columns={columns}
-      data={invitations ?? []}
-      isLoading={isLoading}
-      page={1}
-      pageSize={Math.max(invitations?.length ?? 0, 5)}
-      totalItems={invitations?.length ?? 0}
-      showPagination={false}
-      emptyMessage="No invitations sent."
-      error={isError ? <LoadError onRetry={() => refetch()} /> : undefined}
-    />
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-2">
+        <Input
+          placeholder="Search invitations..."
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          className="h-9 max-w-xs"
+        />
+      </div>
+
+      <DataTable
+        columns={columns}
+        data={filteredInvitations}
+        isLoading={isLoading}
+        page={1}
+        pageSize={Math.max(filteredInvitations.length, 5)}
+        totalItems={filteredInvitations.length}
+        showPagination={false}
+        emptyMessage="No invitations sent."
+        error={isError ? <LoadError onRetry={() => refetch()} /> : undefined}
+      />
+    </div>
   );
 }
 
 function PermissionsTab({ workspaceId }: { workspaceId: string }) {
   const queryClient = useQueryClient();
+  const [search, setSearch] = useState('');
   const [formSheet, setFormSheet] = useState<
     { mode: 'create' } | { mode: 'edit'; groupId: string } | null
   >(null);
@@ -561,11 +579,18 @@ function PermissionsTab({ workspaceId }: { workspaceId: string }) {
         queryClient.invalidateQueries({ queryKey: ['/api/workspaces/members'] });
         invalidateWorkspaceQueries(queryClient);
       },
-      onError: () => toast.error('Failed to delete permission group'),
     },
   });
 
   const canManageGroups = hasPermission('workspace.write');
+
+  const filteredGroups = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return groups ?? [];
+    return (groups ?? []).filter((group) =>
+      group.name.toLowerCase().includes(query),
+    );
+  }, [groups, search]);
 
   const columns: ColumnDef<WorkspacePermissionLike>[] = [
     {
@@ -642,9 +667,19 @@ function PermissionsTab({ workspaceId }: { workspaceId: string }) {
 
   return (
     <div className="space-y-4">
-      <div className="flex justify-end">
+      <div className="flex items-center justify-between gap-2">
+        <Input
+          placeholder="Search permission groups..."
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          className="h-9 max-w-xs"
+        />
         {canManageGroups && (
-          <Button size="sm" onClick={() => setFormSheet({ mode: 'create' })}>
+          <Button
+            size="sm"
+            className="h-9"
+            onClick={() => setFormSheet({ mode: 'create' })}
+          >
             <Plus className="h-4 w-4" />
             Create group
           </Button>
@@ -653,11 +688,11 @@ function PermissionsTab({ workspaceId }: { workspaceId: string }) {
 
       <DataTable
         columns={columns}
-        data={groups ?? []}
+        data={filteredGroups}
         isLoading={isLoading}
         page={1}
-        pageSize={Math.max(groups?.length ?? 0, 5)}
-        totalItems={groups?.length ?? 0}
+        pageSize={Math.max(filteredGroups.length, 5)}
+        totalItems={filteredGroups.length}
         showPagination={false}
         emptyMessage="No permission groups in this workspace."
         error={isError ? <LoadError onRetry={() => refetch()} /> : undefined}
@@ -682,6 +717,7 @@ function InviteMemberDialogContent({
   onClose: () => void;
   queryClient: ReturnType<typeof useQueryClient>;
 }) {
+  const navigate = useNavigate();
   const [emailsText, setEmailsText] = useState('');
   const [selectedGroupIds, setSelectedGroupIds] = useState<string[]>([]);
   const { mutate: createInvitations, isPending } =
@@ -700,7 +736,6 @@ function InviteMemberDialogContent({
           invalidateWorkspaceQueries(queryClient);
           onClose();
         },
-        onError: () => toast.error('Failed to create invitations'),
       },
     });
 
@@ -708,6 +743,8 @@ function InviteMemberDialogContent({
     .split(/[\s,]+/)
     .map((email) => email.trim().toLowerCase())
     .filter((email) => email.length > 0);
+
+  const invitableGroups = groups.filter((group) => !group.isSystem);
 
   return (
     <>
@@ -735,15 +772,27 @@ function InviteMemberDialogContent({
         </div>
         <div className="space-y-2">
           <Label>Permission groups</Label>
-          {groups.length === 0 ? (
+          {invitableGroups.length === 0 ? (
             <p className="text-xs text-muted-foreground">
-              No permission groups yet. Create one in the Permissions tab.
+              No permission groups yet.{' '}
+              <button
+                type="button"
+                className="text-primary underline underline-offset-4 hover:text-primary/80"
+                onClick={() => {
+                  navigate({
+                    to: '/settings/$tab',
+                    params: { tab: 'members' },
+                    search: { tab: 'permissions' },
+                  });
+                  onClose();
+                }}
+              >
+                Create one in the Permissions tab.
+              </button>
             </p>
           ) : (
             <div className="grid gap-2">
-              {groups
-                .filter((group) => !group.isSystem)
-                .map((group) => (
+              {invitableGroups.map((group) => (
                   <label
                     key={group.id}
                     className="flex items-center gap-2 text-sm"


### PR DESCRIPTION
## Summary
UI improvements to the workspace members settings page.

## Changes
- **Invitations tab**: search box filters invitations by email
- **Permission Groups tab**: search box filters groups by name
- **Invite dialog**: only invitable (non-system) groups are listed; added a link that navigates to the Permissions tab when no invitable groups exist
- **Alignment**: consistent `h-9` height for search inputs and buttons
- **Cleanup**: removed redundant `onError` toast handlers (noisy duplicates of TanStack Query defaults)

## Tests
- Added `console/src/__tests__/pages/members-settings.test.tsx` (7 tests)
- Note: local vitest run is blocked by a Windows libuv worker crash (`Assertion failed: handle->reqs_pending == 0, src\win\tcp.c`) — environment issue, not a test failure. CI run pending.