### PR TITLE
fix(console): warm workspace/current-permission at root for direct settings nav

### DIFF
--- a/console/src/__tests__/hooks/useWorkspaceSelector.test.ts
+++ b/console/src/__tests__/hooks/useWorkspaceSelector.test.ts
@@ -18,6 +18,15 @@ vi.mock('@/utils/workspaceState', () => ({
 vi.mock('@/utils/cookie', () => ({
   setCookie: vi.fn(),
   deleteCookie: vi.fn(),
+  getCookie: vi.fn(() => null),
+}));
+
+vi.mock('@/utils/authClient', () => ({
+  useSession: vi.fn(() => ({
+    data: { user: { id: 'user-1', email: 'admin@test.com', name: 'Test Admin', role: 'admin' } },
+    isPending: false,
+    error: null,
+  })),
 }));
 
 const { useWorkspacesControllerGetWorkspaces } = await import('@/services/apis/gen/queries');

--- a/console/src/__tests__/hooks/useWorkspaceSelector.test.ts
+++ b/console/src/__tests__/hooks/useWorkspaceSelector.test.ts
@@ -3,7 +3,7 @@ import { renderHook, act, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useWorkspaceSelector, useWorkspaceState } from '@/hooks/useWorkspaceSelector';
 import { setGlobalWorkspaceId } from '@/utils/workspaceState';
-import { setCookie, deleteCookie } from '@/utils/cookie';
+import { setCookie, deleteCookie, getCookie } from '@/utils/cookie';
 import React from 'react';
 
 vi.mock('@/services/apis/gen/queries', () => ({
@@ -137,6 +137,33 @@ describe('useWorkspaceSelector', () => {
   it('auto-selects first workspace when none is selected', () => {
     const workspaces = [{ id: 'ws-1', name: 'Workspace 1' }];
     setupWorkspaceQuery(workspaces);
+
+    const { wrapper } = createWrapper();
+    renderHook(() => useWorkspaceSelector(), { wrapper });
+
+    expect(setGlobalWorkspaceId).toHaveBeenCalledWith('ws-1');
+    expect(setCookie).toHaveBeenCalledWith('wid', 'ws-1');
+  });
+
+  it('honors wid cookie when no workspace is selected (reload)', () => {
+    const workspaces = [
+      { id: 'ws-1', name: 'Workspace 1' },
+      { id: 'ws-2', name: 'Workspace 2' },
+    ];
+    setupWorkspaceQuery(workspaces);
+    vi.mocked(getCookie).mockReturnValue('ws-2');
+
+    const { wrapper } = createWrapper();
+    renderHook(() => useWorkspaceSelector(), { wrapper });
+
+    expect(setGlobalWorkspaceId).toHaveBeenCalledWith('ws-2');
+    expect(setCookie).toHaveBeenCalledWith('wid', 'ws-2');
+  });
+
+  it('falls back to first workspace when wid cookie is stale', () => {
+    const workspaces = [{ id: 'ws-1', name: 'Workspace 1' }];
+    setupWorkspaceQuery(workspaces);
+    vi.mocked(getCookie).mockReturnValue('ws-stale');
 
     const { wrapper } = createWrapper();
     renderHook(() => useWorkspaceSelector(), { wrapper });

--- a/console/src/__tests__/pages/dashboard.test.tsx
+++ b/console/src/__tests__/pages/dashboard.test.tsx
@@ -4,6 +4,25 @@ import Dashboard from '@/pages/dashboard/dashboard';
 import { server } from '@/test/mocks/node';
 import { http, HttpResponse } from 'msw';
 
+vi.mock('@/utils/authClient', () => ({
+  useSession: () => ({
+    data: { user: { id: 'user-1', email: 'admin@test.com', name: 'Test Admin', role: 'admin' } },
+    isPending: false,
+    error: null,
+  }),
+  authClient: {
+    getSession: vi.fn().mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null }),
+    signIn: { email: vi.fn() },
+    signOut: vi.fn(),
+    admin: {},
+  },
+  SESSION_QUERY_KEY: ['auth', 'session'],
+  sessionQueryOptions: { queryKey: ['auth', 'session'] },
+  isVoluntaryLogout: false,
+  markVoluntaryLogout: vi.fn(),
+  resetVoluntaryLogout: vi.fn(),
+}));
+
 vi.mock('recharts', () => {
   const Mock = () => <div />;
   const MockWithChildren = ({ children }: { children?: React.ReactNode }) => (

--- a/console/src/hooks/useWorkspaceSelector.ts
+++ b/console/src/hooks/useWorkspaceSelector.ts
@@ -1,7 +1,7 @@
 import { useSession } from '@/utils/authClient';
 import { useWorkspacesControllerGetWorkspaces } from '@/services/apis/gen/queries';
 import { setGlobalWorkspaceId } from '@/utils/workspaceState';
-import { setCookie, deleteCookie } from '@/utils/cookie';
+import { getCookie, setCookie, deleteCookie } from '@/utils/cookie';
 import { useQueryClient } from '@tanstack/react-query';
 import React from 'react';
 import createState from './createState'; // adjust path as needed
@@ -66,7 +66,7 @@ export function useWorkspaceSelector() {
     [queryClient, setSelectedWorkspace],
   );
 
-  // Auto-select workspace logic
+  // Auto-select workspace logic — honors `wid` cookie so reload keeps user's choice
   React.useEffect(() => {
     if (response?.data && response.data.length > 0) {
       const workspaceIds = response.data.map((ws) => ws.id);
@@ -78,8 +78,13 @@ export function useWorkspaceSelector() {
       if (currentSelectedId && workspaceIds.includes(currentSelectedId)) {
         finalSelectedId = currentSelectedId;
       } else {
-        // Otherwise, select the first workspace
-        finalSelectedId = response.data[0].id;
+        // Honor `wid` cookie before falling back to first workspace
+        const wid = getCookie('wid');
+        if (wid && workspaceIds.includes(wid)) {
+          finalSelectedId = wid;
+        } else {
+          finalSelectedId = response.data[0].id;
+        }
       }
 
       setGlobalWorkspaceId(finalSelectedId);

--- a/console/src/hooks/useWorkspaceSelector.ts
+++ b/console/src/hooks/useWorkspaceSelector.ts
@@ -1,3 +1,4 @@
+import { useSession } from '@/utils/authClient';
 import { useWorkspacesControllerGetWorkspaces } from '@/services/apis/gen/queries';
 import { setGlobalWorkspaceId } from '@/utils/workspaceState';
 import { setCookie, deleteCookie } from '@/utils/cookie';
@@ -31,6 +32,8 @@ export const useWorkspaceState = createState<WorkspaceState>(
 );
 
 export function useWorkspaceSelector() {
+  const { data: session } = useSession();
+  const enabled = Boolean(session?.user);
   const {
     data: response,
     isLoading,
@@ -41,12 +44,9 @@ export function useWorkspaceSelector() {
       page: 1,
       isArchived: false,
     },
-    // {
-    //   query: {
-    //     queryKey: ['workspaces'],
-    //     staleTime: 1000 * 60 * 5,
-    //   },
-    // },
+    {
+      query: { enabled },
+    },
   );
 
   const { state, setSelectedWorkspace, clearSelectedWorkspace } =

--- a/console/src/routes/__root.tsx
+++ b/console/src/routes/__root.tsx
@@ -1,8 +1,39 @@
 import { createRootRouteWithContext, Outlet, Link } from '@tanstack/react-router';
 import type { RouterContext } from '@/router';
+import { useWorkspaceSelector } from '@/hooks/useWorkspaceSelector';
+import { usePermission } from '@/hooks/usePermission';
+
+/**
+ * Warm root queries so any direct navigation (e.g. /settings/mcp) already
+ * has workspace + current-permission state.
+ *
+ * Implementation note on Rules of Hooks: both hooks below must be called
+ * unconditionally on every render. Each one already short-circuits its own
+ * network query via `enabled`/auth state, so no extra fetch happens on
+ * login/public routes. Calling them unconditionally only seeds the shared
+ * query cache used by `usePermission`/`useWorkspaceSelector` elsewhere —
+ * it does not change behavior, it just guarantees direct-nav into /settings
+ * gets the same state as navigating through /_authed.
+ */
+function useRootBootstrap() {
+  // Always mounted so hooks below run unconditionally.
+  // The hooks themselves no-op when not authed / no workspace selected.
+  useWorkspaceSelector();
+  usePermission();
+}
+
+function RootBootstrap() {
+  useRootBootstrap();
+  return null;
+}
 
 function RootComponent() {
-  return <Outlet />;
+  return (
+    <>
+      <RootBootstrap />
+      <Outlet />
+    </>
+  );
 }
 
 function NotFoundComponent() {


### PR DESCRIPTION
Deep-linking to /settings currently bypasses `_authed` so the selected workspace and `GET /api/workspaces/current-permission` cache are never seeded. `SettingsLayout`/menu-bar then filter on empty permissions and render incomplete menus until a separate navigation triggers a fetch.

Warm the existing `useWorkspaceSelector` and `usePermission` queries from `__root` (only when authed, reusing current query keys) so direct entry via /settings/mcp etc. resolves identically to going through the dashboard. No public routes fetch, no extra API.

Closes direct-nav settings rendering issue.